### PR TITLE
BUG catch cloning errors

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -177,9 +177,12 @@ def run_migrators(feedstock, migrators):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with pushd(tmpdir):
-            # use a full depth clone since some migrators rely on
-            # having all of the branches
-            _run_git_command(["clone", feedstock_http])
+            try:
+                # use a full depth clone since some migrators rely on
+                # having all of the branches
+                _run_git_command(["clone", feedstock_http])
+            except subprocess.CalledProcessError:
+                return made_api_calls
 
             with pushd("%s-feedstock" % feedstock):
                 if os.path.exists("recipe/meta.yaml"):


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
