### PR TITLE
ENH turn CFEP-13 off

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -28,7 +28,7 @@ if DEBUG:
     MAX_MIGRATE = 1
     MAX_SECONDS = 50 * 60
 else:
-    MAX_MIGRATE = 100
+    MAX_MIGRATE = 1000
     MAX_SECONDS = 50 * 60
 
 

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -16,7 +16,8 @@ from admin_migrations.migrators import (
     AutomergeAndRerender,
     AppveyorDelete,
     RAutomerge,
-    CFEP13TokensAndConfig,
+    # CFEP13TokensAndConfig,
+    CFEP13TurnOff,
     # these are finished so we don't run them
     # AutomergeAndBotRerunLabels,
 )
@@ -260,7 +261,8 @@ def main():
         AutomergeAndRerender(),
         AppveyorDelete(),
         RAutomerge(),
-        CFEP13TokensAndConfig(),
+        CFEP13TurnOff(),
+        # CFEP13TokensAndConfig(),
         # these are finished so we don't run them
         # AutomergeAndBotRerunLabels(),
     ]

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -3,4 +3,4 @@ from .automerge_and_rerender import AutomergeAndRerender
 from .automerge_and_botrerun_labels import AutomergeAndBotRerunLabels
 from .appveyor_cleanup import AppveyorDelete
 from .r_automerge import RAutomerge
-from .cfep13_tokens_and_config import CFEP13TokensAndConfig
+from .cfep13_tokens_and_config import CFEP13TokensAndConfig, CFEP13TurnOff

--- a/admin_migrations/migrators/cfep13_tokens_and_config.py
+++ b/admin_migrations/migrators/cfep13_tokens_and_config.py
@@ -7,6 +7,39 @@ from ruamel.yaml import YAML
 from .base import Migrator
 
 
+class CFEP13TurnOff(Migrator):
+    def migrate(self, feedstock, branch):
+
+        with open("conda-forge.yml", "r") as fp:
+            meta_yaml = fp.read()
+
+        if meta_yaml.strip() == "[]" or meta_yaml.strip() == "[ ]":
+            cfg = {}
+        else:
+            yaml = YAML()
+            cfg = yaml.load(meta_yaml)
+
+        if (
+            "conda_forge_output_validation" in cfg
+            and cfg["conda_forge_output_validation"]
+        ):
+            # set the param and write
+            cfg["conda_forge_output_validation"] = False
+            with open("conda-forge.yml", "w") as fp:
+                yaml.dump(cfg, fp)
+            subprocess.run(
+                ["git", "add", "conda-forge.yml"],
+                check=True,
+            )
+            print("    updated conda-forge.yml")
+
+            # migration done, make a commit, lots of API calls
+            return True, True, False
+        else:
+            # migration done, no commits, no API calls
+            return True, False, False
+
+
 class CFEP13TokensAndConfig(Migrator):
     def migrate(self, feedstock, branch):
 
@@ -49,7 +82,7 @@ class CFEP13TokensAndConfig(Migrator):
             print("    added staging binstar token")
 
         # set the param and write
-        cfg["conda_forge_output_validation"] = False
+        cfg["conda_forge_output_validation"] = True
         with open("conda-forge.yml", "w") as fp:
             yaml.dump(cfg, fp)
         subprocess.run(

--- a/data/CFEP13TurnOff.json
+++ b/data/CFEP13TurnOff.json
@@ -1,0 +1,17 @@
+{
+  "cf-autotick-bot-test-package": {
+    "master": true,
+    "azure-azure": true,
+    "azure-circle": true,
+    "azure-travis": true,
+    "circle-azure": true,
+    "circle-circle": true,
+    "circle-travis": true,
+    "rerender-live-test": true,
+    "test-ci-fail": true,
+    "test-ignore-linter": true,
+    "travis-azure": true,
+    "travis-circle": true,
+    "travis-travis": true
+  }
+}


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
