### PR TITLE
ENH conda-forge automerge

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -13,11 +13,12 @@ import github
 import tqdm
 
 from admin_migrations.migrators import (
-    AutomergeAndRerender,
     AppveyorDelete,
     RAutomerge,
     CFEP13TokensAndConfig,
+    CondaForgeAutomerge,
     # these are finished or not used so we don't run them
+    # AutomergeAndRerender,
     # CFEP13TurnOff,
     # AutomergeAndBotRerunLabels,
 )
@@ -261,11 +262,12 @@ def run_migrators(feedstock, migrators):
 
 def main():
     migrators = [
-        AutomergeAndRerender(),
         AppveyorDelete(),
         RAutomerge(),
         CFEP13TokensAndConfig(),
+        CondaForgeAutomerge(),
         # these are finished or not used so we don't run them
+        # AutomergeAndRerender(),
         # CFEP13TurnOff(),
         # AutomergeAndBotRerunLabels(),
     ]

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -4,3 +4,4 @@ from .automerge_and_botrerun_labels import AutomergeAndBotRerunLabels
 from .appveyor_cleanup import AppveyorDelete
 from .r_automerge import RAutomerge
 from .cfep13_tokens_and_config import CFEP13TokensAndConfig, CFEP13TurnOff
+from .conda_forge_automerge import CondaForgeAutomerge

--- a/admin_migrations/migrators/conda_forge_automerge.py
+++ b/admin_migrations/migrators/conda_forge_automerge.py
@@ -1,0 +1,52 @@
+import os
+import subprocess
+
+from .base import Migrator
+
+AUTOMERGE = """\
+on:
+  status: {}
+  check_suite:
+    types:
+      - completed
+
+jobs:
+  automerge-action:
+    runs-on: ubuntu-latest
+    name: automerge
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: automerge-action
+        id: automerge-action
+        uses: conda-forge/automerge-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+"""
+
+
+class CondaForgeAutomerge(Migrator):
+    def migrate(self, feedstock, branch):
+        if (
+            os.path.exists(".github/workflows/automerge.yml")
+            and not os.path.exists(".github/workflows/main.yml")
+        ):
+            return True, False, False
+
+        os.makedirs(".github/workflows", exist_ok=True)
+
+        if not os.path.exists(".github/workflows/automerge.yml"):
+            with open(".github/workflows/automerge.yml", "w") as fp:
+                fp.write(AUTOMERGE)
+            subprocess.run(
+                ["git", "add", ".github/workflows/main.yml"],
+                check=True,
+            )
+
+        if os.path.exists(".github/workflows/main.yml"):
+            subprocess.run(
+                ["git", "rm", "-f", ".github/workflows/main.yml"],
+                check=True,
+            )
+
+        return True, True, False

--- a/admin_migrations/migrators/conda_forge_automerge.py
+++ b/admin_migrations/migrators/conda_forge_automerge.py
@@ -39,7 +39,7 @@ class CondaForgeAutomerge(Migrator):
             with open(".github/workflows/automerge.yml", "w") as fp:
                 fp.write(AUTOMERGE)
             subprocess.run(
-                ["git", "add", ".github/workflows/main.yml"],
+                ["git", "add", ".github/workflows/automerge.yml"],
                 check=True,
             )
 


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.

This PR moves automerge to conda-forge.