### PR TITLE
ENH fix recipe locations

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -13,6 +13,7 @@ import github
 import tqdm
 
 from admin_migrations.migrators import (
+    RecipeLocation,
     AppveyorDelete,
     RAutomerge,
     CFEP13TokensAndConfig,
@@ -262,6 +263,7 @@ def run_migrators(feedstock, migrators):
 
 def main():
     migrators = [
+        RecipeLocation(),
         AppveyorDelete(),
         RAutomerge(),
         CFEP13TokensAndConfig(),

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -5,3 +5,4 @@ from .appveyor_cleanup import AppveyorDelete
 from .r_automerge import RAutomerge
 from .cfep13_tokens_and_config import CFEP13TokensAndConfig, CFEP13TurnOff
 from .conda_forge_automerge import CondaForgeAutomerge
+from .recipe_loc import RecipeLocation

--- a/admin_migrations/migrators/recipe_loc.py
+++ b/admin_migrations/migrators/recipe_loc.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+
+from .base import Migrator
+
+
+class RecipeLocation(Migrator):
+    def migrate(self, feedstock, branch):
+        if (
+            os.path.exists("recipe/recipe/meta.yaml")
+            and not os.path.exists("recipe/meta.yaml")
+        ):
+            subprocess.run(
+                ["git", "mv", "recipe/recipe/*", "recipe/."],
+                check=True,
+
+            )
+            subprocess.run(
+                ["git", "add", "recipe/*"],
+                check=True,
+            )
+
+            # repo is migrated, commit, no api calls
+            return True, True, False
+        else:
+            # repo is migrated, no commits, no api calls
+            return True, False, False


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
