### PR TITLE
PROD quiet git

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -149,7 +149,7 @@ def _load_feedstock_data():
 def _commit_data():
     print("\nsaving data...")
     _run_git_command(["stash"])
-    _run_git_command(["pull"])
+    _run_git_command(["pull", "--quiet"])
     _run_git_command(["stash", "pop"])
     _run_git_command(["add", "data/*.json"])
     _run_git_command(["commit", "-m", "[ci skip] data for admin migration run"])
@@ -161,7 +161,7 @@ def _commit_data():
         "https://%s@github.com/"
         "conda-forge/admin-migrations.git" % os.environ["GITHUB_TOKEN"],
     ])
-    _run_git_command(["push"])
+    _run_git_command(["push", "--quiet"])
 
 
 def run_migrators(feedstock, migrators):
@@ -190,7 +190,7 @@ def run_migrators(feedstock, migrators):
             try:
                 # use a full depth clone since some migrators rely on
                 # having all of the branches
-                _run_git_command(["clone", feedstock_http])
+                _run_git_command(["clone", "--quiet", feedstock_http])
             except subprocess.CalledProcessError:
                 return made_api_calls
 
@@ -238,7 +238,7 @@ def run_migrators(feedstock, migrators):
                                             "[ci skip] [skip ci] [cf admin skip] "
                                             "***NO_CI*** %s" % m.message(),
                                         ])
-                                        _run_git_command(["push"])
+                                        _run_git_command(["push", "--quiet"])
                                     else:
                                         print("not pushing to archived feedstock")
                                 else:

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -192,10 +192,14 @@ def run_migrators(feedstock, migrators):
                 # having all of the branches
                 _run_git_command(["clone", "--quiet", feedstock_http])
             except subprocess.CalledProcessError:
+                print("    clone failed!")
                 return made_api_calls
 
             with pushd("%s-feedstock" % feedstock):
-                if os.path.exists("recipe/meta.yaml"):
+                if (
+                    os.path.exists("recipe/meta.yaml")
+                    or os.path.exists("recipe/recipe/meta.yaml")
+                ):
                     _run_git_command([
                         "remote",
                         "set-url",

--- a/admin_migrations/migrators/cfep13_tokens_and_config.py
+++ b/admin_migrations/migrators/cfep13_tokens_and_config.py
@@ -193,7 +193,7 @@ def _register_feedstock_outputs(feedstock):
         )
 
         subprocess.run(
-            ["git", "pull"],
+            ["git", "pull", "--quiet"],
             check=True,
             cwd=os.environ["FEEDSTOCK_OUTPUTS_REPO"]
         )
@@ -220,7 +220,7 @@ def _register_feedstock_outputs(feedstock):
             )
 
             subprocess.run(
-                ["git", "push"],
+                ["git", "push", "--quiet"],
                 check=True,
                 cwd=os.environ["FEEDSTOCK_OUTPUTS_REPO"]
             )

--- a/admin_migrations/migrators/r_automerge.py
+++ b/admin_migrations/migrators/r_automerge.py
@@ -9,7 +9,12 @@ from .base import Migrator
 def _has_r_team():
     yaml = YAML()
 
-    with open(os.path.join("recipe", "meta.yaml"), "r") as fp:
+    if os.path.exists(os.path.join("recipe", "meta.yaml")):
+        meta_loc = os.path.join("recipe", "meta.yaml")
+    elif os.path.exists(os.path.join("recipe", "recipe", "meta.yaml")):
+        meta_loc = os.path.join("recipe", "recipe", "meta.yaml")
+
+    with open(meta_loc, "r") as fp:
         keep_lines = []
         skip = True
         for line in fp.readlines():
@@ -26,7 +31,12 @@ def _has_r_team():
 def _has_cran_url():
     stop_tokens = ["build:", "requirements:", "test:", "about:", "extra:"]
 
-    with open(os.path.join("recipe", "meta.yaml"), "r") as fp:
+    if os.path.exists(os.path.join("recipe", "meta.yaml")):
+        meta_loc = os.path.join("recipe", "meta.yaml")
+    elif os.path.exists(os.path.join("recipe", "recipe", "meta.yaml")):
+        meta_loc = os.path.join("recipe", "recipe", "meta.yaml")
+
+    with open(meta_loc, "r") as fp:
         in_source_section = False
         for line in fp.readlines():
             if line.startswith("source:"):

--- a/scripts/clone_feedstock_outputs.sh
+++ b/scripts/clone_feedstock_outputs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 rm -rf feedstock-outputs
-git clone https://${GITHUB_TOKEN}@github.com/conda-forge/feedstock-outputs.git
+git clone --quiet https://${GITHUB_TOKEN}@github.com/conda-forge/feedstock-outputs.git
 export FEEDSTOCK_OUTPUTS_REPO=`pwd`/feedstock-outputs
 pushd feedstock-outputs
 git remote set-url --push origin https://${GITHUB_TOKEN}@github.com/conda-forge/feedstock-outputs.git


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
