### PR TITLE
ENH assert ctab always at zero

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -27,7 +27,7 @@ from admin_migrations.migrators import (
 
 def _assert_circle_at_0():
     yaml = ruamel.yaml.YAML()
-    with open(".circle/config.yml", "r") as fp:
+    with open(".circleci/config.yml", "r") as fp:
         _cc_cfg = yaml.load(fp.read())
     ctab = _cc_cfg["workflows"]["hourly"]["triggers"][0]["schedule"]["cron"]
     assert ctab == "00 * * * *", "Wrong cron tab %s for circle!" % ctab


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
