### PR TITLE
BUG always commit

### DIFF
--- a/admin_migrations/migrators/cfep13_token_cleanup.py
+++ b/admin_migrations/migrators/cfep13_token_cleanup.py
@@ -232,17 +232,15 @@ class CFEP13TokenCleanup(Migrator):
         # cleanup conda-forge.yml
         yaml = YAML()
         cfg = _read_conda_forge_yaml(yaml)
-        commit_travis = _cleanup_cfgy(cfg, "travis", "BINSTAR_TOKEN")
-        commit_appveyor = _cleanup_cfgy(cfg, "appveyor", "BINSTAR_TOKEN")
-        commit = commit_travis or commit_appveyor
-        if commit:
-            with open("conda-forge.yml", "w") as fp:
-                yaml.dump(cfg, fp)
-            subprocess.run(
-                ["git", "add", "conda-forge.yml"],
-                check=True,
-            )
-            print("    updated conda-forge.yml")
+        _cleanup_cfgy(cfg, "travis", "BINSTAR_TOKEN")
+        _cleanup_cfgy(cfg, "appveyor", "BINSTAR_TOKEN")
+        with open("conda-forge.yml", "w") as fp:
+            yaml.dump(cfg, fp)
+        subprocess.run(
+            ["git", "add", "conda-forge.yml"],
+            check=True,
+        )
+        print("    updated conda-forge.yml")
 
         # migration done, make a commit, lots of API calls
-        return True, commit, True
+        return True, True, True


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
