### PR TITLE
BUG always commit, but maybe do not push

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -253,17 +253,18 @@ def run_migrators(feedstock, migrators):
                                 print("    ERROR:", repr(e))
 
                             if commit_me:
+                                _run_git_command([
+                                    "commit",
+                                    "--allow-empty",
+                                    "-am",
+                                    "[ci skip] [skip ci] [cf admin skip] "
+                                    "***NO_CI*** %s" % m.message(),
+                                ])
+
                                 made_api_calls = True
                                 is_archived = _repo_is_archived(feedstock)
                                 if is_archived is not None:
                                     if not is_archived:
-                                        _run_git_command([
-                                            "commit",
-                                            "--allow-empty",
-                                            "-am",
-                                            "[ci skip] [skip ci] [cf admin skip] "
-                                            "***NO_CI*** %s" % m.message(),
-                                        ])
                                         _run_git_command(["push", "--quiet"])
                                     else:
                                         print("not pushing to archived feedstock")


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
