### PR TITLE
ENH add admin migration to reconfigure travis

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -18,6 +18,7 @@ from admin_migrations.migrators import (
     RAutomerge,
     TeamsCleanup,
     CFEP13TokenCleanup,
+    TravisCIAutoCancelPRs,
     # these are finished or not used so we don't run them
     # CondaForgeAutomerge,
     # CFEP13TokensAndConfig,
@@ -293,6 +294,7 @@ def main():
         RAutomerge(),
         TeamsCleanup(),
         CFEP13TokenCleanup(),
+        TravisCIAutoCancelPRs(),
         # these are finished or not used so we don't run them
         # CondaForgeAutomerge(),
         # CFEP13TokensAndConfig(),

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -7,3 +7,4 @@ from .cfep13_tokens_and_config import CFEP13TokensAndConfig, CFEP13TurnOff
 from .conda_forge_automerge import CondaForgeAutomerge
 from .teams_cleanup import TeamsCleanup
 from .cfep13_token_cleanup import CFEP13TokenCleanup
+from .travis_auto_cancel_prs import TravisCIAutoCancelPRs

--- a/admin_migrations/migrators/travis_auto_cancel_prs.py
+++ b/admin_migrations/migrators/travis_auto_cancel_prs.py
@@ -1,0 +1,56 @@
+import requests
+
+from .base import Migrator
+
+
+def _travis_reconfigure(user, project):
+    from conda_smithy.ci_register import (
+        travis_endpoint,
+        travis_headers,
+        travis_get_repo_info,
+    )
+
+    headers = travis_headers()
+    repo_info = travis_get_repo_info(user, project)
+
+    if not repo_info:
+        return False
+
+    repo_id = repo_info["id"]
+
+    if repo_info["active"] is not True:
+        return True
+
+    settings = [
+        ("auto_cancel_pull_requests", True),
+    ]
+    for name, value in settings:
+        url = "{}/repo/{repo_id}/setting/{name}".format(
+            travis_endpoint, repo_id=repo_id, name=name
+        )
+        data = {"setting.value": value}
+        response = requests.patch(url, json=data, headers=headers)
+        if response.status_code != 204:
+            return False
+
+    return True
+
+
+class TravisCIAutoCancelPRs(Migrator):
+    master_branch_only = True
+
+    def migrate(self, feedstock, branch):
+        user = "conda-forge"
+        project = "%s-feedstock" % feedstock
+
+        if branch == "master":
+            done = _travis_reconfigure(user, project)
+            if done:
+                print("    configured travis-ci", flush=True)
+            else:
+                print("    error in configuring travis-ci", flush=True)
+        else:
+            done = True
+
+        # migration done, make a commit, lots of API calls
+        return done, False, True


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
