### PR TITLE
REF change token cleanup

### DIFF
--- a/admin_migrations/migrators/cfep13_token_cleanup.py
+++ b/admin_migrations/migrators/cfep13_token_cleanup.py
@@ -191,6 +191,7 @@ class CFEP13TokenCleanup(Migrator):
 
         if branch == "master":
             # these two token changes are not needed anymore
+            # staged-recipes does this by default now
             # put the staging token into BINSTAR_TOKEN
             # subprocess.run(
             #     "conda smithy update-binstar-token "

--- a/admin_migrations/migrators/cfep13_token_cleanup.py
+++ b/admin_migrations/migrators/cfep13_token_cleanup.py
@@ -225,7 +225,7 @@ class CFEP13TokenCleanup(Migrator):
 
             # remove BINSTAR_TOKEN and STAGING_BINSTAR_TOKEN from azure
             # this removes the tokens attached to the specific pipeline, not the org
-            # we should move thios bit of code to staged recipes and then turn this off
+            # we should move this bit of code to staged recipes and then turn this off
             _delete_tokens_in_azure(
                 user,
                 project,

--- a/admin_migrations/migrators/cfep13_token_cleanup.py
+++ b/admin_migrations/migrators/cfep13_token_cleanup.py
@@ -190,25 +190,26 @@ class CFEP13TokenCleanup(Migrator):
         project = "%s-feedstock" % feedstock
 
         if branch == "master":
+            # these two token changes are not needed anymore
             # put the staging token into BINSTAR_TOKEN
-            subprocess.run(
-                "conda smithy update-binstar-token "
-                "--without-appveyor --without-azure "
-                "--token_name BINSTAR_TOKEN",
-                shell=True,
-                check=True
-            )
-            print("    putting cf-staging binstar token in BINSTAR_TOKEN")
+            # subprocess.run(
+            #     "conda smithy update-binstar-token "
+            #     "--without-appveyor --without-azure "
+            #     "--token_name BINSTAR_TOKEN",
+            #     shell=True,
+            #     check=True
+            # )
+            # print("    putting cf-staging binstar token in BINSTAR_TOKEN")
 
             # put the staging token into STAGING_BINSTAR_TOKEN
-            subprocess.run(
-                "conda smithy update-binstar-token "
-                "--without-appveyor --without-azure "
-                "--token_name STAGING_BINSTAR_TOKEN",
-                shell=True,
-                check=True
-            )
-            print("    putting cf-staging binstar token in STAGING_BINSTAR_TOKEN")
+            # subprocess.run(
+            #     "conda smithy update-binstar-token "
+            #     "--without-appveyor --without-azure "
+            #     "--token_name STAGING_BINSTAR_TOKEN",
+            #     shell=True,
+            #     check=True
+            # )
+            # print("    putting cf-staging binstar token in STAGING_BINSTAR_TOKEN")
 
             # needs a change in smithy so cannot do this
             # # remove STAGING_BINSTAR_TOKEN from travis, circle and drone
@@ -222,6 +223,8 @@ class CFEP13TokenCleanup(Migrator):
             # print("    deleted STAGING_BINSTAR_TOKEN from travis")
 
             # remove BINSTAR_TOKEN and STAGING_BINSTAR_TOKEN from azure
+            # this removes the tokens attached to the specific pipeline, not the org
+            # we should move thios bit of code to staged recipes and then turn this off
             _delete_tokens_in_azure(
                 user,
                 project,


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
