### PR TITLE
ENH add azure-only token cleanup

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -10,20 +10,9 @@ jobs:
     name: migrate
     runs-on: "ubuntu-latest"
     steps:
-      - name: skip me
-        shell: bash -l {0}
-        if: success() && contains(github.event.head_commit.message, 'ci skip')
-        run: |
-          echo "commit message: '${MSG}'"
-          echo "CI_SKIP=true" >> $GITHUB_ENV
-        env:
-          MSG: ${{ github.event.head_commit.message }}
-
       - uses: actions/checkout@v2
-        if: success() && ! env.CI_SKIP
 
       - uses: conda-incubator/setup-miniconda@v2
-        if: success() && ! env.CI_SKIP
         with:
           python-version: 3.8
           channels: conda-forge,defaults
@@ -31,7 +20,6 @@ jobs:
           show-channel-urls: true
 
       - name: configure conda and install code
-        if: success() && ! env.CI_SKIP
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
@@ -46,7 +34,6 @@ jobs:
           git config --global user.name "cf-blacksmithy"
 
       - name: migrate
-        if: success() && ! env.CI_SKIP
         shell: bash -l {0}
         run: |
           mkdir -p ~/.conda-smithy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,26 +11,14 @@ jobs:
     name: tests
     runs-on: "ubuntu-latest"
     steps:
-      - name: skip me
-        shell: bash -l {0}
-        if: success() && contains(github.event.head_commit.message, 'ci skip')
-        run: |
-          echo "commit message: '${MSG}'"
-          echo "CI_SKIP=true" >> $GITHUB_ENV
-        env:
-          MSG: ${{ github.event.head_commit.message }}
-
       - name: cancel previous runs
         uses: styfle/cancel-workflow-action@0.6.0
-        if: success() && ! env.CI_SKIP
         with:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-        if: success() && ! env.CI_SKIP
 
       - uses: conda-incubator/setup-miniconda@v2
-        if: success() && ! env.CI_SKIP
         with:
           python-version: 3.8
           channels: conda-forge,defaults
@@ -38,7 +26,6 @@ jobs:
           show-channel-urls: true
 
       - name: configure conda and install code
-        if: success() && ! env.CI_SKIP
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
@@ -53,13 +40,11 @@ jobs:
           git config --global user.name "cf-blacksmithy"
 
       - name: lint
-        if: success() && ! env.CI_SKIP
         shell: bash -l {0}
         run: |
           flake8 admin_migrations
 
       - name: test
-        if: success() && ! env.CI_SKIP
         shell: bash -l {0}
         run: |
           mkdir -p ~/.conda-smithy
@@ -69,7 +54,6 @@ jobs:
           echo ${AZURE_TOKEN} > ~/.conda-smithy/azure.token
           echo ${DRONE_TOKEN} > ~/.conda-smithy/drone.token
           echo ${GITHUB_TOKEN} > ~/.conda-smithy/github.token
-
 
           export DEBUG_ADMIN_MIGRATIONS=1
           source ./scripts/clone_feedstock_outputs.sh

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -16,8 +16,9 @@ import ruamel.yaml
 from admin_migrations.migrators import (
     RAutomerge,
     TeamsCleanup,
-    CFEP13TokenCleanup,
+    CFEP13AzureTokenCleanup,
     # these are finished or not used so we don't run them
+    # CFEP13TokenCleanup,
     # AppveyorForceDelete,
     # TravisCIAutoCancelPRs,
     # CondaForgeAutomerge,
@@ -325,8 +326,9 @@ def main():
     migrators = [
         RAutomerge(),
         TeamsCleanup(),
-        CFEP13TokenCleanup(),
+        CFEP13AzureTokenCleanup(),
         # these are finished or not used so we don't run them
+        # CFEP13TokenCleanup(),
         # AppveyorForceDelete(),
         # TravisCIAutoCancelPRs(),
         # CondaForgeAutomerge(),

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -8,3 +8,4 @@ from .conda_forge_automerge import CondaForgeAutomerge
 from .teams_cleanup import TeamsCleanup
 from .cfep13_token_cleanup import CFEP13TokenCleanup
 from .travis_auto_cancel_prs import TravisCIAutoCancelPRs
+from .cfep13_azure_token_cleanup import CFEP13AzureTokenCleanup

--- a/admin_migrations/migrators/cfep13_azure_token_cleanup.py
+++ b/admin_migrations/migrators/cfep13_azure_token_cleanup.py
@@ -1,0 +1,68 @@
+from .base import Migrator
+
+
+def _delete_tokens_in_azure(user, project, token_names):
+    from conda_smithy.azure_ci_utils import build_client, get_default_build_definition
+    from conda_smithy.azure_ci_utils import default_config as config
+
+    bclient = build_client()
+
+    existing_definitions = bclient.get_definitions(
+        project=config.project_name, name=project
+    )
+    if existing_definitions:
+        assert len(existing_definitions) == 1
+        ed = existing_definitions[0]
+    else:
+        raise RuntimeError(
+            "Cannot delete tokens %s from a repo that is not already "
+            "registerd on azure CI!"
+            % token_names
+        )
+
+    ed = bclient.get_definition(ed.id, project=config.project_name)
+
+    if not hasattr(ed, "variables") or ed.variables is None:
+        variables = {}
+    else:
+        variables = ed.variables
+
+    for token_name in token_names:
+        if token_name in variables:
+            del variables[token_name]
+
+    build_definition = get_default_build_definition(
+        user,
+        project,
+        config=config,
+        variables=variables,
+        id=ed.id,
+        revision=ed.revision,
+    )
+
+    bclient.update_definition(
+        definition=build_definition,
+        definition_id=ed.id,
+        project=ed.project.name,
+    )
+
+
+class CFEP13AzureTokenCleanup(Migrator):
+    master_branch_only = True
+
+    def migrate(self, feedstock, branch):
+        user = "conda-forge"
+        project = "%s-feedstock" % feedstock
+
+        if branch == "master":
+            # remove BINSTAR_TOKEN and STAGING_BINSTAR_TOKEN from azure
+            # this removes the tokens attached to the specific pipeline, not the org
+            _delete_tokens_in_azure(
+                user,
+                project,
+                ["BINSTAR_TOKEN", "STAGING_BINSTAR_TOKEN"],
+            )
+            print("    deleted BINSTAR_TOKEN and STAGING_BINSTAR_TOKEN from azure")
+
+        # migration done, make a commit, lots of API calls
+        return True, False, True


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
