### PR TITLE
ENH rotate tokens and make default branch agnostic

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
       avoid massive rebuilds.
 - [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
 - [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
-- [ ] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
+- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
        token's API requests.
 - [ ] Do not rerender feedstocks!
 

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -25,15 +25,17 @@ jobs:
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
 
       - name: configure conda and install code
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
           conda config --add channels conda-forge
-          conda install --quiet pip
+          mamba install --quiet pip
 
-          conda install -y -q --file requirements.txt
+          mamba install -y -q --file requirements.txt
 
           pip install --no-deps -e .
 

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -41,6 +41,7 @@ jobs:
 
           git config --global user.email "pelson.pub+conda-forge@gmail.com"
           git config --global user.name "conda-forge-admin"
+          git config --global pull.rebase false
 
       - name: migrate
         shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
 
           git config --global user.email "pelson.pub+conda-forge@gmail.com"
           git config --global user.name "conda-forge-admin"
+          git config --global pull.rebase false
 
       - name: lint
         shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           app_id: ${{ secrets.CF_CURATOR_APP_ID }}
           private_key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
-      
+
       - name: cancel previous runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:
@@ -31,15 +31,17 @@ jobs:
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
 
       - name: configure conda and install code
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
           conda config --add channels conda-forge
-          conda install --quiet pip
+          mamba install --quiet pip
 
-          conda install -y -q --file requirements.txt
+          mamba install -y -q --file requirements.txt
 
           pip install --no-deps -e .
 

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -108,7 +108,7 @@ def _get_curr_branch():
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
-    return o.decode("utf=8").strip()
+    return o.stdout.decode("utf=8").strip()
 
 
 def _get_branches(default_branch):

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -103,7 +103,7 @@ def _run_git_command(args, capture=False, check=True):
 
 def _get_curr_branch():
     o = subprocess.run(
-        "git rev-parse --abbrev-ref HEAD",
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
         check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -9,4 +9,4 @@ from .teams_cleanup import TeamsCleanup
 from .cfep13_token_cleanup import CFEP13TokenCleanup
 from .travis_auto_cancel_prs import TravisCIAutoCancelPRs
 from .cfep13_azure_token_cleanup import CFEP13AzureTokenCleanup
-from .rotate_feedstock_token import RotateFeedstockToken
+from .rotate_feedstock_tokens import RotateFeedstockToken

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -9,3 +9,4 @@ from .teams_cleanup import TeamsCleanup
 from .cfep13_token_cleanup import CFEP13TokenCleanup
 from .travis_auto_cancel_prs import TravisCIAutoCancelPRs
 from .cfep13_azure_token_cleanup import CFEP13AzureTokenCleanup
+from .rotate_feedstock_token import RotateFeedstockToken

--- a/admin_migrations/migrators/appveyor_cleanup.py
+++ b/admin_migrations/migrators/appveyor_cleanup.py
@@ -62,13 +62,13 @@ def _has_appveyor_any_branch(curr_branch):
 
 class AppveyorDelete(Migrator):
     # we need to check each branch, but this migrator should only be called
-    # once per feedstock on the master branch
-    master_branch_only = False
+    # once per feedstock on the main branch
+    main_branch_only = False
 
     def migrate(self, feedstock, branch):
         HEADERS = {"Authorization": "Bearer " + os.environ['APPVEYOR_TOKEN']}
 
-        assert branch == "master"
+        assert branch == "main" or branch == "master"
         deleted = False
 
         appveyor_name = "%s-feedstock" % feedstock
@@ -139,7 +139,7 @@ class AppveyorDelete(Migrator):
 
 
 class AppveyorForceDelete(Migrator):
-    master_branch_only = True
+    main_branch_only = True
 
     def migrate(self, feedstock, branch):
         HEADERS = {"Authorization": "Bearer " + os.environ['APPVEYOR_TOKEN']}

--- a/admin_migrations/migrators/automerge_and_botrerun_labels.py
+++ b/admin_migrations/migrators/automerge_and_botrerun_labels.py
@@ -19,7 +19,7 @@ AUTOMERGE = (
 
 
 class AutomergeAndBotRerunLabels(Migrator):
-    master_branch_only = True
+    main_branch_only = True
 
     def migrate(self, feedstock, branch):
         try:

--- a/admin_migrations/migrators/automerge_and_rerender.py
+++ b/admin_migrations/migrators/automerge_and_rerender.py
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
       - name: regro-cf-autotick-bot-action
         id: regro-cf-autotick-bot-action
-        uses: regro/cf-autotick-bot-action@master
+        uses: regro/cf-autotick-bot-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 """
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: webservices
         id: webservices
-        uses: conda-forge/webservices-dispatch-action@master
+        uses: conda-forge/webservices-dispatch-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 """

--- a/admin_migrations/migrators/base.py
+++ b/admin_migrations/migrators/base.py
@@ -3,9 +3,9 @@ import json
 
 
 class Migrator(object):
-    # set this to true if the admin migration runs for the master branch only
+    # set this to true if the admin migration runs for the main branch only
     # this can be used for migrations that update CI services used by all branches
-    master_branch_only = False
+    main_branch_only = False
 
     def __init__(self):
         self._load_done_table()

--- a/admin_migrations/migrators/base.py
+++ b/admin_migrations/migrators/base.py
@@ -30,7 +30,14 @@ class Migrator(object):
 
         Note this method cannot depend on the feedstock contents.
         """
-        return self._done_table.get(feedstock, {}).get(branch, False)
+        if branch != "main":
+            return self._done_table.get(feedstock, {}).get(branch, False)
+        else:
+            return (
+                self._done_table.get(feedstock, {}).get("master", False)
+                or
+                self._done_table.get(feedstock, {}).get("main", False)
+            )
 
     def migrate(self, feedstock, branch):
         """Migrate the feedstock.

--- a/admin_migrations/migrators/cfep13_azure_token_cleanup.py
+++ b/admin_migrations/migrators/cfep13_azure_token_cleanup.py
@@ -48,13 +48,13 @@ def _delete_tokens_in_azure(user, project, token_names):
 
 
 class CFEP13AzureTokenCleanup(Migrator):
-    master_branch_only = True
+    main_branch_only = True
 
     def migrate(self, feedstock, branch):
         user = "conda-forge"
         project = "%s-feedstock" % feedstock
 
-        if branch == "master":
+        if branch == "master" or branch == "main":
             # remove BINSTAR_TOKEN and STAGING_BINSTAR_TOKEN from azure
             # this removes the tokens attached to the specific pipeline, not the org
             _delete_tokens_in_azure(

--- a/admin_migrations/migrators/cfep13_token_cleanup.py
+++ b/admin_migrations/migrators/cfep13_token_cleanup.py
@@ -189,7 +189,7 @@ class CFEP13TokenCleanup(Migrator):
         user = "conda-forge"
         project = "%s-feedstock" % feedstock
 
-        if branch == "master":
+        if branch == "master" or branch == "main":
             # these two token changes are not needed anymore
             # staged-recipes does this by default now
             # put the staging token into BINSTAR_TOKEN

--- a/admin_migrations/migrators/cfep13_tokens_and_config.py
+++ b/admin_migrations/migrators/cfep13_tokens_and_config.py
@@ -243,7 +243,7 @@ class CFEP13TokensAndConfig(Migrator):
             # migration done, no commits, no API calls
             return True, False, False
 
-        if branch == "master":
+        if branch == "master" or branch == "main":
             # register a feedstock token
             # this call is idempotent if the token already exists
             _register_feedstock_token(feedstock)

--- a/admin_migrations/migrators/conda_forge_automerge.py
+++ b/admin_migrations/migrators/conda_forge_automerge.py
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
       - name: automerge-action
         id: automerge-action
-        uses: conda-forge/automerge-action@master
+        uses: conda-forge/automerge-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 """

--- a/admin_migrations/migrators/rotate_feedstock_tokens.py
+++ b/admin_migrations/migrators/rotate_feedstock_tokens.py
@@ -1,0 +1,112 @@
+import os
+import requests
+import subprocess
+import tempfile
+
+from .base import Migrator
+
+SMITHY_CONF = os.path.expanduser('~/.conda-smithy')
+
+
+def _feedstock_token_exists(name):
+    r = requests.get(
+        "https://api.github.com/repos/conda-forge/"
+        "feedstock-tokens/contents/tokens/%s.json" % (name),
+        headers={"Authorization": "token %s" % os.environ["GITHUB_TOKEN"]},
+    )
+    if r.status_code != 200:
+        return False
+    else:
+        return True
+
+
+def _delete_feedstock_token(feedstock_name):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(
+            "git clone https://x-access-token:${GITHUB_TOKEN}@github.com/conda-forge/"
+            "feedstock-tokens.git",
+            cwd=tmpdir,
+            shell=True,
+        )
+
+        subprocess.check_call(
+            "git remote set-url --push origin "
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/conda-forge/"
+            "feedstock-tokens.git",
+            cwd=os.path.join(tmpdir, "feedstock-tokens"),
+            shell=True,
+        )
+
+        subprocess.check_call(
+            "git rm tokens/%s.json" % feedstock_name,
+            cwd=os.path.join(tmpdir, "feedstock-tokens"),
+            shell=True,
+        )
+
+        subprocess.check_call(
+            "git commit --allow-empty -am "
+            "'[ci skip] [skip ci] [cf admin skip] ***NO_CI*** removing "
+            "token for %s'" % feedstock_name,
+            cwd=os.path.join(tmpdir, "feedstock-tokens"),
+            shell=True,
+        )
+
+        subprocess.check_call(
+            "git pull",
+            cwd=os.path.join(tmpdir, "feedstock-tokens"),
+            shell=True,
+        )
+
+        subprocess.check_call(
+            "git push",
+            cwd=os.path.join(tmpdir, "feedstock-tokens"),
+            shell=True,
+        )
+
+
+class RotateFeedstockToken(Migrator):
+    main_branch_only = True
+
+    def migrate(self, feedstock, branch):
+        # delete the old token
+        if _feedstock_token_exists(feedstock + "-feedstock"):
+            _delete_feedstock_token(feedstock + "-feedstock")
+            print("    deleted old feedstock token")
+
+        feedstock_dir = "../%s-feedstock" % feedstock
+        owner_info = ['--organization', 'conda-forge']
+
+        # make a new one
+        subprocess.check_call(
+            " ".join(
+                [
+                    'conda', 'smithy', 'generate-feedstock-token',
+                    '--feedstock_directory', feedstock_dir
+                ]
+                + owner_info
+            ),
+            shell=True,
+        )
+        print("    created new feedstock token")
+
+        # register
+        subprocess.check_call(
+            " ".join(
+                [
+                    'conda', 'smithy',
+                    'register-feedstock-token', '--feedstock_directory',
+                    feedstock_dir
+                ]
+                + owner_info
+                + [
+                    '--token_repo',
+                    'https://x-access-token:${GITHUB_TOKEN}@github.com/conda-forge/'
+                    'feedstock-tokens'
+                ]
+            ),
+            shell=True,
+        )
+        print("    registered new feedstock token")
+
+        # migration done, make a commit, lots of API calls
+        return True, False, True

--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -20,7 +20,7 @@ class DummyMeta(object):
 
 
 class TeamsCleanup(Migrator):
-    master_branch_only = True
+    main_branch_only = True
 
     def migrate(self, feedstock, branch):
         repo_name = "%s-feedstock" % feedstock

--- a/admin_migrations/migrators/travis_auto_cancel_prs.py
+++ b/admin_migrations/migrators/travis_auto_cancel_prs.py
@@ -40,13 +40,13 @@ def _travis_reconfigure(user, project):
 
 
 class TravisCIAutoCancelPRs(Migrator):
-    master_branch_only = True
+    main_branch_only = True
 
     def migrate(self, feedstock, branch):
         user = "conda-forge"
         project = "%s-feedstock" % feedstock
 
-        if branch == "master":
+        if branch == "master" or branch == "main":
             done = _travis_reconfigure(user, project)
             if done:
                 print("    configured travis-ci", flush=True)

--- a/scripts/2020_02_00_old_migrate_script/migrate_rerender.sh
+++ b/scripts/2020_02_00_old_migrate_script/migrate_rerender.sh
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: webservices
         id: webservices
-        uses: conda-forge/webservices-dispatch-action@master
+        uses: conda-forge/webservices-dispatch-action@main
         with:
           github_token: \${{ secrets.GITHUB_TOKEN }}" > .github/workflows/webservices.yml
 
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v2
       - name: regro-cf-autotick-bot-action
         id: regro-cf-autotick-bot-action
-        uses: regro/cf-autotick-bot-action@master
+        uses: regro/cf-autotick-bot-action@main
         with:
           github_token: \${{ secrets.GITHUB_TOKEN }}" > .github/workflows/main.yml
 


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] CircleCI has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
