### PR TITLE
ENH pure API calls

### DIFF
--- a/admin_migrations/migrators/rotate_feedstock_tokens.py
+++ b/admin_migrations/migrators/rotate_feedstock_tokens.py
@@ -36,8 +36,8 @@ def _delete_feedstock_token(feedstock_name):
     if fn is not None:
         FEEDSTOCK_TOKENS_REPO.delete_file(
             token_file,
-            "'[ci skip] [skip ci] [cf admin skip] ***NO_CI*** removing "
-            "token for %s'" % feedstock_name,
+            "[ci skip] [skip ci] [cf admin skip] ***NO_CI*** removing "
+            "token for %s" % feedstock_name,
             fn.sha,
         )
 

--- a/admin_migrations/migrators/rotate_feedstock_tokens.py
+++ b/admin_migrations/migrators/rotate_feedstock_tokens.py
@@ -27,19 +27,13 @@ def _feedstock_token_exists(name):
 
 def _delete_feedstock_token(feedstock_name):
     token_file = "tokens/%s.json" % feedstock_name
-    try:
-        fn = FEEDSTOCK_TOKENS_REPO.get_contents(token_file)
-    except Exception:
-        fn = None
-        pass
-
-    if fn is not None:
-        FEEDSTOCK_TOKENS_REPO.delete_file(
-            token_file,
-            "[ci skip] [skip ci] [cf admin skip] ***NO_CI*** removing "
-            "token for %s" % feedstock_name,
-            fn.sha,
-        )
+    fn = FEEDSTOCK_TOKENS_REPO.get_contents(token_file)
+    FEEDSTOCK_TOKENS_REPO.delete_file(
+        token_file,
+        "[ci skip] [skip ci] [cf admin skip] ***NO_CI*** removing "
+        "token for %s" % feedstock_name,
+        fn.sha,
+    )
 
 
 class RotateFeedstockToken(Migrator):

--- a/admin_migrations/migrators/rotate_feedstock_tokens.py
+++ b/admin_migrations/migrators/rotate_feedstock_tokens.py
@@ -1,12 +1,16 @@
 import os
 import requests
 import subprocess
-import tempfile
-import time
+import github
 
 from .base import Migrator
 
 SMITHY_CONF = os.path.expanduser('~/.conda-smithy')
+FEEDSTOCK_TOKENS_REPO = (
+    github
+    .Github(os.environ["GITHUB_TOKEN"])
+    .get_repo("conda-forge/feedstock-tokens")
+)
 
 
 def _feedstock_token_exists(name):
@@ -22,62 +26,20 @@ def _feedstock_token_exists(name):
 
 
 def _delete_feedstock_token(feedstock_name):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        if "FEEDSTOCK_TOKENS_REPO" in os.environ:
-            repo_cwd = os.environ["FEEDSTOCK_TOKENS_REPO"]
-        else:
-            subprocess.check_call(
-                "git clone https://x-access-token:${GITHUB_TOKEN}@"
-                "github.com/conda-forge/"
-                "feedstock-tokens.git",
-                cwd=tmpdir,
-                shell=True,
-            )
+    token_file = "tokens/%s.json" % feedstock_name
+    try:
+        fn = FEEDSTOCK_TOKENS_REPO.get_contents(token_file)
+    except Exception:
+        fn = None
+        pass
 
-            subprocess.check_call(
-                "git remote set-url --push origin "
-                "https://x-access-token:${GITHUB_TOKEN}@github.com/conda-forge/"
-                "feedstock-tokens.git",
-                cwd=os.path.join(tmpdir, "feedstock-tokens"),
-                shell=True,
-            )
-            repo_cwd = os.path.join(tmpdir, "feedstock-tokens")
-
-        subprocess.check_call(
-            "git rm tokens/%s.json" % feedstock_name,
-            cwd=repo_cwd,
-            shell=True,
-        )
-
-        subprocess.check_call(
-            "git commit --allow-empty -am "
+    if fn is not None:
+        FEEDSTOCK_TOKENS_REPO.delete_file(
+            token_file,
             "'[ci skip] [skip ci] [cf admin skip] ***NO_CI*** removing "
             "token for %s'" % feedstock_name,
-            cwd=repo_cwd,
-            shell=True,
+            fn.sha,
         )
-
-        ntry = 5
-        for i in range(ntry):
-            try:
-                subprocess.check_call(
-                    "git pull",
-                    cwd=repo_cwd,
-                    shell=True,
-                )
-
-                subprocess.check_call(
-                    "git push",
-                    cwd=repo_cwd,
-                    shell=True,
-                )
-
-                break
-            except Exception as e:
-                if i < ntry-1:
-                    time.seep(0.050 * 2**i)
-                else:
-                    raise e
 
 
 class RotateFeedstockToken(Migrator):

--- a/scripts/clone_feedstock_outputs.sh
+++ b/scripts/clone_feedstock_outputs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-for slug in outputs tokens; do
+for slug in outputs; do
   upper_slug=$(echo "$slug" | tr '[:lower:]' '[:upper:]')
   rm -rf feedstock-${slug}
   git clone --quiet https://x-access-token:${GITHUB_TOKEN}@github.com/conda-forge/feedstock-${slug}.git


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
