### PR TITLE
ENH migrate workflow files to main

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -15,6 +15,7 @@ import ruamel.yaml
 
 from admin_migrations.migrators import (
     RAutomerge,
+    CondaForgeGHAWithMain,
     # these are finished or not used so we don't run them
     # RotateCFStagingToken,
     # RotateFeedstockToken,
@@ -343,6 +344,7 @@ def run_migrators(feedstock, migrators):
 def main():
     migrators = [
         RAutomerge(),
+        CondaForgeGHAWithMain(),
         # these are finished or not used so we don't run them
         # RotateCFStagingToken(),
         # RotateFeedstockToken(),

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -11,3 +11,4 @@ from .travis_auto_cancel_prs import TravisCIAutoCancelPRs
 from .cfep13_azure_token_cleanup import CFEP13AzureTokenCleanup
 from .rotate_feedstock_tokens import RotateFeedstockToken
 from .rotate_cf_staging_token import RotateCFStagingToken
+from .main_default_branch import CondaForgeGHAWithMain

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -21,6 +21,7 @@ jobs:
         uses: conda-forge/automerge-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}
 """
 
 WEBSERVICES = """\

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -1,0 +1,60 @@
+import subprocess
+
+from .base import Migrator
+
+AUTOMERGE = """\
+on:
+  status: {}
+  check_suite:
+    types:
+      - completed
+
+jobs:
+  automerge-action:
+    runs-on: ubuntu-latest
+    name: automerge
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: automerge-action
+        id: automerge-action
+        uses: conda-forge/automerge-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+"""
+
+WEBSERVICES = """\
+on: repository_dispatch
+
+jobs:
+  webservices:
+    runs-on: ubuntu-latest
+    name: webservices
+    steps:
+      - name: webservices
+        id: webservices
+        uses: conda-forge/webservices-dispatch-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}
+"""
+
+
+class CondaForgeGHAWithMain(Migrator):
+    def migrate(self, feedstock, branch):
+        with open(".github/workflows/automerge.yml", "w") as fp:
+            fp.write(AUTOMERGE)
+        subprocess.run(
+            ["git", "add", ".github/workflows/automerge.yml"],
+            check=True,
+        )
+
+        with open(".github/workflows/webservices.yml", "w") as fp:
+            fp.write(WEBSERVICES)
+        subprocess.run(
+            ["git", "add", ".github/workflows/webservices.yml"],
+            check=True,
+        )
+
+        # migration done, make a commit, lots of API calls
+        return True, True, False


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
