### PR TITLE
BUG make sure to not run feedstock builds when renaming

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -344,8 +344,9 @@ def run_migrators(feedstock, migrators):
 
 def main():
     migrators = [
+        CondaForgeMasterToMain(),  # this one always goes first since it makes extra
+                                   # commits etc
         RAutomerge(),
-        # CondaForgeMasterToMain(),
         # these are finished or not used so we don't run them
         # CondaForgeGHAWithMain(),
         # RotateCFStagingToken(),

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -87,21 +87,14 @@ def pushd(new_dir):
         os.chdir(previous_dir)
 
 
-def _run_git_command(args, capture=False, check=True):
-    if capture:
-        subprocess.run(
-            ['git'] + args,
-            check=check,
-        )
-        return None
-    else:
-        s = subprocess.run(
-            ['git'] + args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=check,
-        )
-        return s.returncode == 0, s.stdout.decode("utf-8")
+def _run_git_command(args, check=True):
+    s = subprocess.run(
+        ['git'] + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=check,
+    )
+    return s.returncode == 0, s.stdout.decode("utf-8")
 
 
 def _get_curr_branch():
@@ -275,7 +268,6 @@ def run_migrators(feedstock, migrators):
                                 try:
                                     _run_git_command(
                                         ["switch", branch],
-                                        capture=True,
                                         check=True,
                                     )
                                 except Exception:
@@ -285,7 +277,6 @@ def run_migrators(feedstock, migrators):
                                             "-b", branch,
                                             "-t", "origin/" + branch
                                         ],
-                                        capture=True,
                                         check=False,
                                     )
                                     if not ok:

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -94,6 +94,8 @@ def _run_git_command(args, check=True):
         stderr=subprocess.STDOUT,
         check=check,
     )
+    if s.returncode != 0:
+        print(f"    ERROR: {s.stdout.decode('utf-8')}", flush=True)
     return s.returncode == 0, s.stdout.decode("utf-8")
 
 

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -268,7 +268,7 @@ def _master_to_main(repo):
         return False
 
     rev_sha = _get_curr_sha()
-
+    worked = False
     try:
         # once pygithub 1.56 or greater is out we can use this
         # repo.rename_branch(repo.default_branch, "main")
@@ -282,11 +282,7 @@ def _master_to_main(repo):
     except Exception as e:
         print(f"    ERROR: {repr(e)}", flush=True)
         print("    master to main rename FAILED in the API!", flush=True)
-        _run_git_command(["revert", "-n", rev_sha])
-        _commit_repo("turning on CI for master to main migration")
-        _run_git_command(["push", "--quiet"])
-        print("    turned CI back on for master to main migration", flush=True)
-        return False
+        worked = False
     else:
         time.sleep(5)
         print("    renamed branch '%s' to 'main'" % repo.default_branch, flush=True)
@@ -294,12 +290,14 @@ def _master_to_main(repo):
         # the upstream branch has changed, so need to reset local clone
         _reset_local_branch(repo.default_branch)
         print("    reset local branch to 'main'", flush=True)
-
+        worked = True
+    finally:
         _run_git_command(["revert", "-n", rev_sha])
         _commit_repo("turning on CI for master to main migration")
         _run_git_command(["push", "--quiet"])
         print("    turned CI back on for master to main migration", flush=True)
-        return True
+
+    return worked
 
 
 class CondaForgeMasterToMain(Migrator):

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -219,12 +219,10 @@ def _get_curr_sha():
 
 def _reset_local_branch(old_def_branch):
     subprocess.run(
-        "git stash && "
         f"git branch -m {old_def_branch} main && "
         "git fetch origin && "
         "git branch -u origin/main main && "
-        "git remote set-head origin -a && "
-        "git stash pop",
+        "git remote set-head origin -a ",
         check=True,
         shell=True,
     )

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -249,7 +249,8 @@ def _master_to_main(repo):
 
         _commit_repo("turning off CI for master to main migration")
         print("    turned off CI for master to main migration", flush=True)
-    except Exception:
+    except Exception as e:
+        print(repr(e))
         print(
             "    turning off CI for master to main migration FAILED on commit!",
             flush=True,
@@ -259,7 +260,8 @@ def _master_to_main(repo):
 
     try:
         _run_git_command(["push", "--quiet"])
-    except Exception:
+    except Exception as e:
+        print(repr(e))
         print(
             "    turning off CI for master to main migration FAILED on push!",
             flush=True,
@@ -279,7 +281,8 @@ def _master_to_main(repo):
             json={"new_name": "main"},
         )
         r.raise_for_status()
-    except Exception:
+    except Exception as e:
+        print(repr(e))
         print("    master to main rename FAILED in the API!", flush=True)
         _run_git_command(["revert", "-n", rev_sha])
         _commit_repo("turning on CI for master to main migration")
@@ -313,6 +316,7 @@ class CondaForgeMasterToMain(Migrator):
             did_master_to_main = _master_to_main(repo)
         else:
             did_master_to_main = False
+            make_commit = False
 
         if did_master_to_main:
             # the conda-forge config gets updated every time

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -235,12 +235,12 @@ def _master_to_main(repo):
     try:
         if os.path.exists("azure-pipelines.yml"):
             _run_git_command(
-                "git", "mv", "azure-pipelines.yml", "azure-pipelines.yml.bak",
+                "mv", "azure-pipelines.yml", "azure-pipelines.yml.bak",
             )
 
         if os.path.exists(".travis.yml"):
             _run_git_command(
-                "git", "mv", ".travis.yml", ".travis.yml.bak",
+                "mv", ".travis.yml", ".travis.yml.bak",
             )
 
         if os.path.exists(".circleci/config.yml"):
@@ -254,7 +254,7 @@ def _master_to_main(repo):
             "    turning off CI for master to main migration FAILED on commit!",
             flush=True,
         )
-        _run_git_command(["git", "reset", "--hard", old_sha])
+        _run_git_command(["reset", "--hard", old_sha])
         return False
 
     try:
@@ -264,7 +264,7 @@ def _master_to_main(repo):
             "    turning off CI for master to main migration FAILED on push!",
             flush=True,
         )
-        _run_git_command(["git", "reset", "--hard", old_sha])
+        _run_git_command(["reset", "--hard", old_sha])
         return False
 
     rev_sha = _get_curr_sha()
@@ -281,7 +281,7 @@ def _master_to_main(repo):
         r.raise_for_status()
     except Exception:
         print("    master to main rename FAILED in the API!", flush=True)
-        _run_git_command(["git", "revert", "-n", rev_sha])
+        _run_git_command(["revert", "-n", rev_sha])
         _commit_repo("turning on CI for master to main migration")
         _run_git_command(["push", "--quiet"])
         print("    turned CI back on for master to main migration", flush=True)
@@ -294,7 +294,7 @@ def _master_to_main(repo):
         _reset_local_branch(repo.default_branch)
         print("    reset local branch to 'main'", flush=True)
 
-        _run_git_command(["git", "revert", "-n", rev_sha])
+        _run_git_command(["revert", "-n", rev_sha])
         _commit_repo("turning on CI for master to main migration")
         _run_git_command(["push", "--quiet"])
         print("    turned CI back on for master to main migration", flush=True)
@@ -311,6 +311,8 @@ class CondaForgeMasterToMain(Migrator):
         # only call branch rename once on current "master" branch if it exists
         if repo.default_branch != "main" and branch == repo.default_branch:
             did_master_to_main = _master_to_main(repo)
+        else:
+            did_master_to_main = False
 
         if did_master_to_main:
             # the conda-forge config gets updated every time

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -123,6 +123,9 @@ def _run_git_command(args, check=True):
         stderr=subprocess.STDOUT,
         check=check,
     )
+    if s.returncode != 0:
+        print(f"    ERROR: {s.stdout.decode('utf-8')}", flush=True)
+
     return s.returncode == 0, s.stdout.decode("utf-8")
 
 
@@ -211,14 +214,18 @@ def _get_curr_sha():
 
 
 def _reset_local_branch(old_def_branch):
-    subprocess.run(
+    s = subprocess.run(
         f"git branch -m {old_def_branch} main && "
         "git fetch origin && "
         "git branch -u origin/main main && "
         "git remote set-head origin -a ",
         check=True,
         shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
     )
+    if s.returncode != 0:
+        print(f"    ERROR: {s.stdout.decode('utf-8')}", flush=True)
 
 
 def _master_to_main(repo):

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -234,14 +234,14 @@ def _master_to_main(repo):
     old_sha = _get_curr_sha()
     try:
         if os.path.exists("azure-pipelines.yml"):
-            _run_git_command(
+            _run_git_command([
                 "mv", "azure-pipelines.yml", "azure-pipelines.yml.bak",
-            )
+            ])
 
         if os.path.exists(".travis.yml"):
-            _run_git_command(
+            _run_git_command([
                 "mv", ".travis.yml", ".travis.yml.bak",
-            )
+            ])
 
         if os.path.exists(".circleci/config.yml"):
             with open(".circleci/config.yml", "w") as fp:
@@ -250,7 +250,7 @@ def _master_to_main(repo):
         _commit_repo("turning off CI for master to main migration")
         print("    turned off CI for master to main migration", flush=True)
     except Exception as e:
-        print(repr(e))
+        print(f"    ERROR: {repr(e)}", flush=True)
         print(
             "    turning off CI for master to main migration FAILED on commit!",
             flush=True,
@@ -261,7 +261,7 @@ def _master_to_main(repo):
     try:
         _run_git_command(["push", "--quiet"])
     except Exception as e:
-        print(repr(e))
+        print(f"    ERROR: {repr(e)}", flush=True)
         print(
             "    turning off CI for master to main migration FAILED on push!",
             flush=True,
@@ -282,7 +282,7 @@ def _master_to_main(repo):
         )
         r.raise_for_status()
     except Exception as e:
-        print(repr(e))
+        print(f"    ERROR: {repr(e)}", flush=True)
         print("    master to main rename FAILED in the API!", flush=True)
         _run_git_command(["revert", "-n", rev_sha])
         _commit_repo("turning on CI for master to main migration")

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -312,7 +312,8 @@ class CondaForgeMasterToMain(Migrator):
             did_master_to_main = _master_to_main(repo)
         else:
             did_master_to_main = False
-            make_commit = False
+
+        make_commit = False
 
         if did_master_to_main:
             # the conda-forge config gets updated every time

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -116,21 +116,14 @@ jobs:
 """
 
 
-def _run_git_command(args, capture=False, check=True):
-    if capture:
-        subprocess.run(
-            ['git'] + args,
-            check=check,
-        )
-        return None
-    else:
-        s = subprocess.run(
-            ['git'] + args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=check,
-        )
-        return s.returncode == 0, s.stdout.decode("utf-8")
+def _run_git_command(args, check=True):
+    s = subprocess.run(
+        ['git'] + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=check,
+    )
+    return s.returncode == 0, s.stdout.decode("utf-8")
 
 
 def _commit_repo(msg):

--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -11,6 +11,33 @@ from .base import Migrator
 
 GH = github.Github(os.environ['GITHUB_TOKEN'])
 
+CIRCLECI_BLANK = """
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+version: 2
+
+jobs:
+  build:
+    working_directory: ~/test
+    machine: true
+    steps:
+      - run:
+          # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
+          command: exit 0
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+"""  # noqa
+
 AUTOMERGE_MAIN = """\
 on:
   status: {}
@@ -89,6 +116,33 @@ jobs:
 """
 
 
+def _run_git_command(args, capture=False, check=True):
+    if capture:
+        subprocess.run(
+            ['git'] + args,
+            check=check,
+        )
+        return None
+    else:
+        s = subprocess.run(
+            ['git'] + args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=check,
+        )
+        return s.returncode == 0, s.stdout.decode("utf-8")
+
+
+def _commit_repo(msg):
+    _run_git_command([
+        "commit",
+        "--allow-empty",
+        "-am",
+        "[ci skip] [skip ci] [cf admin skip] "
+        "***NO_CI*** %s" % msg,
+    ])
+
+
 @lru_cache(maxsize=1)
 def _get_req_session(github_token):
     # based on
@@ -153,6 +207,16 @@ def _update_wfl(fname, new_wfl):
         return False
 
 
+def _get_curr_sha():
+    o = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    return o.stdout.decode("utf=8").strip()
+
+
 def _reset_local_branch(old_def_branch):
     subprocess.run(
         "git stash && "
@@ -166,6 +230,77 @@ def _reset_local_branch(old_def_branch):
     )
 
 
+def _master_to_main(repo):
+    old_sha = _get_curr_sha()
+    try:
+        if os.path.exists("azure-pipelines.yml"):
+            _run_git_command(
+                "git", "mv", "azure-pipelines.yml", "azure-pipelines.yml.bak",
+            )
+
+        if os.path.exists(".travis.yml"):
+            _run_git_command(
+                "git", "mv", ".travis.yml", ".travis.yml.bak",
+            )
+
+        if os.path.exists(".circleci/config.yml"):
+            with open(".circleci/config.yml", "w") as fp:
+                fp.write(CIRCLECI_BLANK)
+
+        _commit_repo("turning off CI for master to main migration")
+        print("    turned off CI for master to main migration", flush=True)
+    except Exception:
+        print(
+            "    turning off CI for master to main migration FAILED on commit!",
+            flush=True,
+        )
+        _run_git_command(["git", "reset", "--hard", old_sha])
+        return False
+
+    try:
+        _run_git_command(["push", "--quiet"])
+    except Exception:
+        print(
+            "    turning off CI for master to main migration FAILED on push!",
+            flush=True,
+        )
+        _run_git_command(["git", "reset", "--hard", old_sha])
+        return False
+
+    rev_sha = _get_curr_sha()
+
+    try:
+        # once pygithub 1.56 or greater is out we can use this
+        # repo.rename_branch(repo.default_branch, "main")
+        sess = _get_req_session(os.environ['GITHUB_TOKEN'])
+        r = sess.post(
+            "https://api.github.com"
+            "/repos/%s/branches/%s/rename" % (repo.full_name, repo.default_branch),
+            json={"new_name": "main"},
+        )
+        r.raise_for_status()
+    except Exception:
+        print("    master to main rename FAILED in the API!", flush=True)
+        _run_git_command(["git", "revert", "-n", rev_sha])
+        _commit_repo("turning on CI for master to main migration")
+        _run_git_command(["push", "--quiet"])
+        print("    turned CI back on for master to main migration", flush=True)
+        return False
+    else:
+        time.sleep(5)
+        print("    renamed branch '%s' to 'main'" % repo.default_branch, flush=True)
+
+        # the upstream branch has changed, so need to reset local clone
+        _reset_local_branch(repo.default_branch)
+        print("    reset local branch to 'main'", flush=True)
+
+        _run_git_command(["git", "revert", "-n", rev_sha])
+        _commit_repo("turning on CI for master to main migration")
+        _run_git_command(["push", "--quiet"])
+        print("    turned CI back on for master to main migration", flush=True)
+        return True
+
+
 class CondaForgeMasterToMain(Migrator):
     def migrate(self, feedstock, branch):
         repo = GH.get_repo("conda-forge/%s-feedstock" % feedstock)
@@ -173,68 +308,54 @@ class CondaForgeMasterToMain(Migrator):
             # migration done, make a commit, lots of API calls
             return True, False, True
 
-        # the conda-forge config gets updated every time
-        updated_automerge = _update_wfl(
-            ".github/workflows/automerge.yml", AUTOMERGE_MAIN,
-        )
-        updated_webservices = _update_wfl(
-            ".github/workflows/webservices.yml", WEBSERVICES_MAIN,
-        )
-
-        yaml = YAML()
-        cfg = _read_conda_forge_yaml(yaml)
-        if "github" not in cfg:
-            cfg["github"] = {}
-        if (
-            "branch_name" not in cfg["github"]
-            or cfg["github"]["branch_name"] != "main"
-            or "tooling_branch_name" not in cfg["github"]
-            or cfg["github"]["tooling_branch_name"] != "main"
-            or (
-                "upload_on_branch" in cfg
-                and cfg["upload_on_branch"] == "master"
-            )
-        ):
-            cfg["github"]["branch_name"] = "main"
-            cfg["github"]["tooling_branch_name"] = "main"
-
-            if "upload_on_branch" in cfg and cfg["upload_on_branch"] == "master":
-                cfg["upload_on_branch"] = "main"
-
-            with open("conda-forge.yml", "w") as fp:
-                yaml.dump(cfg, fp)
-            subprocess.run(
-                ["git", "add", "conda-forge.yml"],
-                check=True,
-            )
-            print("    updated conda-forge.yml", flush=True)
-            updated_cfy = True
-        else:
-            updated_cfy = False
-
-        make_commit = updated_automerge or updated_webservices or updated_cfy
-
         # only call branch rename once on current "master" branch if it exists
         if repo.default_branch != "main" and branch == repo.default_branch:
-            # once pygithub 1.56 or greater is out we can use this
-            # repo.rename_branch(repo.default_branch, "main")
+            did_master_to_main = _master_to_main(repo)
 
-            sess = _get_req_session(os.environ['GITHUB_TOKEN'])
-            r = sess.post(
-                "https://api.github.com"
-                "/repos/%s/branches/%s/rename" % (repo.full_name, repo.default_branch),
-                json={"new_name": "main"},
+        if did_master_to_main:
+            # the conda-forge config gets updated every time
+            updated_automerge = _update_wfl(
+                ".github/workflows/automerge.yml", AUTOMERGE_MAIN,
             )
-            r.raise_for_status()
-            time.sleep(5)
-            print("    renamed branch '%s' to 'main'" % repo.default_branch, flush=True)
+            updated_webservices = _update_wfl(
+                ".github/workflows/webservices.yml", WEBSERVICES_MAIN,
+            )
 
-            # the upstream branch has changed, so need to reset local clone
-            _reset_local_branch(repo.default_branch)
-            print("    reset local branch to 'main'", flush=True)
+            yaml = YAML()
+            cfg = _read_conda_forge_yaml(yaml)
+            if "github" not in cfg:
+                cfg["github"] = {}
+            if (
+                "branch_name" not in cfg["github"]
+                or cfg["github"]["branch_name"] != "main"
+                or "tooling_branch_name" not in cfg["github"]
+                or cfg["github"]["tooling_branch_name"] != "main"
+                or (
+                    "upload_on_branch" in cfg
+                    and cfg["upload_on_branch"] == "master"
+                )
+            ):
+                cfg["github"]["branch_name"] = "main"
+                cfg["github"]["tooling_branch_name"] = "main"
+
+                if "upload_on_branch" in cfg and cfg["upload_on_branch"] == "master":
+                    cfg["upload_on_branch"] = "main"
+
+                with open("conda-forge.yml", "w") as fp:
+                    yaml.dump(cfg, fp)
+                subprocess.run(
+                    ["git", "add", "conda-forge.yml"],
+                    check=True,
+                )
+                print("    updated conda-forge.yml", flush=True)
+                updated_cfy = True
+            else:
+                updated_cfy = False
+
+            make_commit = updated_automerge or updated_webservices or updated_cfy
 
         # migration done, make a commit, lots of API calls
-        return True, make_commit, True
+        return did_master_to_main, make_commit, True
 
 
 class CondaForgeGHAWithMain(Migrator):


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
