### PR TITLE
ENH remove extra pause

### DIFF
--- a/admin_migrations/migrators/main_default_branch.py
+++ b/admin_migrations/migrators/main_default_branch.py
@@ -267,11 +267,6 @@ def _master_to_main(repo):
         _run_git_command(["reset", "--hard", old_sha])
         return False
 
-    # sometimes the push event in the github api gets behind the
-    # branch rename and this causes the webservices to freak out
-    # we delay a bit to help this not happen
-    time.sleep(2)
-
     rev_sha = _get_curr_sha()
     worked = False
     try:


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
