### PR TITLE
ENH move to .conda

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -20,6 +20,7 @@ from admin_migrations.migrators import (
     CondaForgeMasterToMain,
     FeedstocksServiceUpdate,
     CondaForgeAutomergeUpdate,
+    DotConda,
     # these are finished or not used so we don't run them
     # CondaForgeGHAWithMain,
     # RotateCFStagingToken,
@@ -367,6 +368,7 @@ def main():
         TraviCINoOSXAMD64(),
         FeedstocksServiceUpdate(),
         CondaForgeAutomergeUpdate(),
+        DotConda(),
         # these are finished or not used so we don't run them
         # CondaForgeGHAWithMain(),
         # RotateCFStagingToken(),

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -14,3 +14,4 @@ from .rotate_cf_staging_token import RotateCFStagingToken
 from .main_default_branch import CondaForgeGHAWithMain, CondaForgeMasterToMain
 from .travis_cleanup_osx_amd64 import TraviCINoOSXAMD64
 from .feedstocks_service_update import FeedstocksServiceUpdate
+from .dot_conda import DotConda

--- a/admin_migrations/migrators/dot_conda.py
+++ b/admin_migrations/migrators/dot_conda.py
@@ -40,8 +40,13 @@ class DotConda(Migrator):
 
         yaml = YAML()
         cfg = _read_conda_forge_yaml(yaml)
-        if "conda_pkg_format" not in cfg:
-            cfg["conda_pkg_format"] = "2"
+        if (
+            "conda_build" not in cfg
+            or "pkg_format" not in cfg["conda_build"]
+        ):
+            if "conda_build" not in cfg:
+                cfg["conda_build"] = {}
+            cfg["conda_build"]["pkg_format"] = "2"
             with open("conda-forge.yml", "w") as fp:
                 yaml.dump(cfg, fp)
             subprocess.run(

--- a/admin_migrations/migrators/dot_conda.py
+++ b/admin_migrations/migrators/dot_conda.py
@@ -1,0 +1,57 @@
+import subprocess
+import os
+
+import github
+from ruamel.yaml import YAML
+
+from .base import Migrator
+
+GH = github.Github(os.environ['GITHUB_TOKEN'])
+
+
+def _read_conda_forge_yaml(yaml):
+    if os.path.exists("conda-forge.yml"):
+        with open("conda-forge.yml", "r") as fp:
+            meta_yaml = fp.read()
+
+        if (
+            meta_yaml is None
+            or meta_yaml.strip() == "[]"
+            or meta_yaml.strip() == "[ ]"
+            or len(meta_yaml) == 0
+            or len(meta_yaml.strip()) == 0
+        ):
+            cfg = {}
+        else:
+            cfg = yaml.load(meta_yaml)
+    else:
+        meta_yaml = ""
+        cfg = {}
+
+    return cfg
+
+
+class DotConda(Migrator):
+    def migrate(self, feedstock, branch):
+        repo = GH.get_repo("conda-forge/%s-feedstock" % feedstock)
+        if repo.archived:
+            # migration done, make a commit, lots of API calls
+            return True, False, False
+
+        yaml = YAML()
+        cfg = _read_conda_forge_yaml(yaml)
+        if "conda_pkg_format" not in cfg:
+            cfg["conda_pkg_format"] = "2"
+            with open("conda-forge.yml", "w") as fp:
+                yaml.dump(cfg, fp)
+            subprocess.run(
+                ["git", "add", "conda-forge.yml"],
+                check=True,
+            )
+            print("    updated conda-forge.yml", flush=True)
+            updated_cfy = True
+        else:
+            updated_cfy = False
+
+        # migration done, make a commit, lots of API calls
+        return True, updated_cfy, False


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
