### PR TITLE
DEP turn off old migrations

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -17,13 +17,13 @@ import ruamel.yaml
 from admin_migrations.migrators import (
     RAutomerge,
     TraviCINoOSXAMD64,
-    CondaForgeMasterToMain,
-    FeedstocksServiceUpdate,
-    CondaForgeAutomergeUpdate,
-    DotConda,
     RotateCFStagingToken,
     RotateFeedstockToken,
     # these are finished or not used so we don't run them
+    # CondaForgeMasterToMain,
+    # FeedstocksServiceUpdate,
+    # CondaForgeAutomergeUpdate,
+    # DotConda,
     # CondaForgeGHAWithMain,
     # CFEP13AzureTokenCleanup,
     # TeamsCleanup,
@@ -362,16 +362,16 @@ def _report_progress(
 
 def main():
     migrators = [
-        CondaForgeMasterToMain(),  # this one always goes first since it makes extra
-                                   # commits etc
         RAutomerge(),
         TraviCINoOSXAMD64(),
-        FeedstocksServiceUpdate(),
-        CondaForgeAutomergeUpdate(),
-        DotConda(),
         RotateCFStagingToken(),
         RotateFeedstockToken(),
         # these are finished or not used so we don't run them
+        # CondaForgeMasterToMain(),  # this one always goes first since it makes extra
+        #                            # commits etc
+        # FeedstocksServiceUpdate(),
+        # CondaForgeAutomergeUpdate(),
+        # DotConda(),
         # CondaForgeGHAWithMain(),
         # RotateCFStagingToken(),
         # RotateFeedstockToken(),


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
