### PR TITLE
BUG make sure travis api is working before rotating tokens

### DIFF
--- a/admin_migrations/migrators/rotate_cf_staging_token.py
+++ b/admin_migrations/migrators/rotate_cf_staging_token.py
@@ -1,5 +1,7 @@
 import subprocess
 
+from conda_smithy.ci_register import travis_get_repo_info
+
 from .base import Migrator
 
 
@@ -8,6 +10,16 @@ class RotateCFStagingToken(Migrator):
     max_workers = 1
 
     def migrate(self, feedstock, branch):
+        # test to make sure travis ci api is working
+        # if not skip migration
+        repo_info = travis_get_repo_info("conda-forge", feedstock+"-feedstock")
+        if not repo_info:
+            print(
+                "    travis-ci API not working - skipping migration for now",
+                flush=True,
+            )
+            return False, False, True
+
         subprocess.run(
             "conda smithy update-binstar-token "
             "--without-appveyor --without-azure "

--- a/admin_migrations/migrators/rotate_feedstock_tokens.py
+++ b/admin_migrations/migrators/rotate_feedstock_tokens.py
@@ -3,6 +3,8 @@ import requests
 import subprocess
 import github
 
+from conda_smithy.ci_register import travis_get_repo_info
+
 from .base import Migrator
 
 SMITHY_CONF = os.path.expanduser('~/.conda-smithy')
@@ -41,6 +43,16 @@ class RotateFeedstockToken(Migrator):
     max_processes = 1
 
     def migrate(self, feedstock, branch):
+        # test to make sure travis ci api is working
+        # if not skip migration
+        repo_info = travis_get_repo_info("conda-forge", feedstock+"-feedstock")
+        if not repo_info:
+            print(
+                "    travis-ci API not working - skipping migration for now",
+                flush=True,
+            )
+            return False, False, True
+
         # delete the old token
         if _feedstock_token_exists(feedstock + "-feedstock"):
             _delete_feedstock_token(feedstock + "-feedstock")


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
