### PR TITLE
PROD stop token rotation

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -17,9 +17,9 @@ import ruamel.yaml
 from admin_migrations.migrators import (
     RAutomerge,
     TraviCINoOSXAMD64,
-    RotateCFStagingToken,
-    RotateFeedstockToken,
     # these are finished or not used so we don't run them
+    # RotateCFStagingToken,
+    # RotateFeedstockToken,
     # CondaForgeMasterToMain,
     # FeedstocksServiceUpdate,
     # CondaForgeAutomergeUpdate,
@@ -364,9 +364,9 @@ def main():
     migrators = [
         RAutomerge(),
         TraviCINoOSXAMD64(),
-        RotateCFStagingToken(),
-        RotateFeedstockToken(),
         # these are finished or not used so we don't run them
+        # RotateCFStagingToken(),
+        # RotateFeedstockToken(),
         # CondaForgeMasterToMain(),  # this one always goes first since it makes extra
         #                            # commits etc
         # FeedstocksServiceUpdate(),


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
