### PR TITLE
Admin migration for conda-forge.yml test_on_native_only

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -17,6 +17,7 @@ import ruamel.yaml
 from admin_migrations.migrators import (
     RAutomerge,
     TraviCINoOSXAMD64,
+    CondaForgeYAMLTest,
     # these are finished or not used so we don't run them
     # RotateCFStagingToken,
     # RotateFeedstockToken,
@@ -364,6 +365,7 @@ def main():
     migrators = [
         RAutomerge(),
         TraviCINoOSXAMD64(),
+        CondaForgeYAMLTest(),
         # these are finished or not used so we don't run them
         # RotateCFStagingToken(),
         # RotateFeedstockToken(),

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -15,3 +15,4 @@ from .main_default_branch import CondaForgeGHAWithMain, CondaForgeMasterToMain
 from .travis_cleanup_osx_amd64 import TraviCINoOSXAMD64
 from .feedstocks_service_update import FeedstocksServiceUpdate
 from .dot_conda import DotConda
+from .conda_forge_yml_test import CondaForgeYAMLTest

--- a/admin_migrations/migrators/conda_forge_yml_test.py
+++ b/admin_migrations/migrators/conda_forge_yml_test.py
@@ -1,0 +1,40 @@
+import os
+import subprocess
+
+from ruamel.yaml import YAML
+
+from .base import Migrator
+
+
+class CondaForgeYAMLTest(Migrator):
+    """Cleanup conda-forge.yml test_on_native_only
+    """
+    def migrate(self, feedstock, branch):
+        with open("conda-forge.yml", "r") as fp:
+            meta_yaml = fp.read()
+
+        if meta_yaml.strip() == "[]" or meta_yaml.strip() == "[ ]":
+            cfg = {}
+        else:
+            yaml = YAML()
+            cfg = yaml.load(meta_yaml)
+
+        if "test_on_native_only" not in cfg:
+            # no migration, no commit needs to be made, no api calls
+            return False, False, False
+
+        value = cfg["test_on_native_only"]
+        del cfg["test_on_native_only"]
+        if str(value) in ["True", "true"] and "test" not in cfg:
+            cfg["test"] = "native_and_emulated"
+
+        with open("conda-forge.yml", "w") as fp:
+            yaml.dump(cfg, fp)
+
+        subprocess.run(
+            ["git", "add", "conda-forge.yml"],
+            check=True,
+        )
+
+        # did migration, make a commit, no api calls
+        return True, True, False

--- a/admin_migrations/migrators/conda_forge_yml_test.py
+++ b/admin_migrations/migrators/conda_forge_yml_test.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 from ruamel.yaml import YAML


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make
any big changes.
