### PR TITLE
feat: add support for rattler-build recipe.yaml

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -255,6 +255,8 @@ def run_migrators(feedstock, migrators):
                 if (
                     os.path.exists("recipe/meta.yaml")
                     or os.path.exists("recipe/recipe/meta.yaml")
+                    # This is a rattler-build recipe
+                    or os.path.exists("recipe/recipe.yaml")
                 ):
                     _run_git_command([
                         "remote",

--- a/admin_migrations/migrators/r_automerge.py
+++ b/admin_migrations/migrators/r_automerge.py
@@ -27,6 +27,23 @@ def _has_r_team():
     maints = [m.strip() for m in maints]
     return "conda-forge/r" in maints
 
+def _has_r_team_rattler_build():
+    """Check if the recipe has a conda-forge/r maintainer. Works with rattler-build recipes"""
+    yaml = YAML()
+    recipe_location = os.path.join("recipe", "recipe.yaml")
+    if not os.path.exists(recipe_location):
+        return False
+    try:
+        with open("recipe/recipe.yaml", "r") as file:
+            yaml = yaml.load(file)
+        if "extra" in yaml:
+            if "recipe-maintainers" in yaml["extra"]:
+                maints = yaml["extra"]["recipe-maintainers"]
+                maints = [m.strip() for m in maints]
+                return "conda-forge/r" in maints
+    except Exception as e:
+        return False
+
 
 def _has_cran_url():
     stop_tokens = ["build:", "requirements:", "test:", "about:", "extra:"]
@@ -57,6 +74,101 @@ def _has_cran_url():
 
     return False
 
+def _has_cran_url_rattler_build():
+    """Check if the recipe has a cran url in the source section. Works with rattler-build recipes
+    Collect all urls in the source section and check if any of them are cran urls.
+    Can be conditionally a single source or a list of sources
+    i.e.
+    ```
+     source: # case 1
+       url: https://cran.r-project.org/src/contrib/foo
+    ```
+     or
+    ```
+     source: # case 2
+       - url: https://cran.r-project.org/src/contrib/foo
+       - url: https://cran.r-project.org/src/contrib/bar
+    ```
+    we can also contain an conditional, these may not be nested:
+    ```
+     if something:
+     then:
+         - url: https://cran.r-project.org/src/contrib/foo
+     else:
+         - url: https://cran.r-project.org/src/contrib/bar
+    ```
+    Which can in turn contain a source or a list of sources (case 1 or case 2)
+    """
+
+    yaml = YAML()
+    recipe_location = os.path.join("recipe", "recipe.yaml")
+    MIRROR = "cran_mirror"
+    CONTRIB = "cran.r-project.org/src/contrib"
+
+
+    # Helper functions
+    def _check_source(source):
+        """Check if a source has a cran url"""
+        if source and "url" in source:
+            return MIRROR in source["url"] or CONTRIB in source["url"]
+        return False
+
+    def _check_list_of_sources(sources):
+        """Check if a list of sources has a cran url"""
+        for source in sources:
+            if _check_source(source):
+                return True
+        return False
+
+    def _check_source_or_list_of_sources(branch):
+        """Check if a branch of a conditional has a cran url
+        which can again be a source or a list of sources
+        """
+        if branch:
+            if isinstance(branch, dict) and "url" in branch:
+                return _check_source(branch)
+            if isinstance(branch, list):
+                return _check_list_of_sources(branch)
+
+    def _check_conditional(then, elze):
+        """Check if a conditional has a cran url"""
+        if then:
+            # Check the then branch of the conditional
+            return _check_source_or_list_of_sources(then)
+        if elze:
+            # Check the else branch of the conditional
+            return _check_source_or_list_of_sources(elze)
+        return False
+
+    def _check_source_or_conditional(source):
+        """Check if a source has a cran url or if it is a conditional that may contain a cran url"""
+        if _check_source(source):
+            return True
+        return _check_conditional(source.get("then"), source.get("else"))
+
+    if not os.path.exists(recipe_location):
+        return False
+    try:
+        with open("recipe/recipe.yaml", "r") as file:
+            recipe = yaml.load(file)
+            # Check for top-level source attribute(s)
+            if "source" in recipe:
+                sources = yaml["source"]
+                if isinstance(sources, dict):
+                    # Can only be a source or a conditional
+                    return _check_source_or_conditional(sources)
+                elif isinstance(sources, list):
+                    for source in sources:
+                        # A list that can contain both direct sources and conditionals
+                        if _check_source_or_conditional(source):
+                            return True
+            # There can also be outputs that produce sources and no top level sources
+            # but I think this is also ignored in the `meta.yaml` case, so ignoring it here as well
+    except Exception as e:
+        return False
+
+    return False
+
 
 class RAutomerge(Migrator):
     """Adds bot automerge to any feedstock that has
@@ -72,8 +184,8 @@ class RAutomerge(Migrator):
         if (
             feedstock.startswith("r-")
             and feedstock != "r-base"
-            and _has_r_team()
-            and _has_cran_url()
+            and (_has_r_team() or _has_r_team_rattler_build())
+            and (_has_cran_url() or _has_cran_url_rattler_build())
         ):
             with open("conda-forge.yml", "r") as fp:
                 meta_yaml = fp.read()

--- a/admin_migrations/migrators/r_automerge.py
+++ b/admin_migrations/migrators/r_automerge.py
@@ -5,6 +5,11 @@ from ruamel.yaml import YAML
 
 from .base import Migrator
 
+from rattler_build_conda_compat.recipe_sources import get_all_url_sources
+
+
+MIRROR = "cran_mirror"
+CONTRIB = "cran.r-project.org/src/contrib"
 
 def _has_r_team():
     yaml = YAML()
@@ -66,8 +71,8 @@ def _has_cran_url():
                 (
                     # this same set of slugs is used by the autotick bot
                     # https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/migrators/version.py#L71
-                    "cran_mirror" in line
-                    or "cran.r-project.org/src/contrib" in line
+                    MIRROR in line
+                    or CONTRIB in line
                 )
             ):
                 return True
@@ -98,72 +103,23 @@ def _has_cran_url_rattler_build():
          - url: https://cran.r-project.org/src/contrib/bar
     ```
     Which can in turn contain a source or a list of sources (case 1 or case 2)
+
+    Outputs can have similar sources as well
     """
 
     yaml = YAML()
     recipe_location = os.path.join("recipe", "recipe.yaml")
-    MIRROR = "cran_mirror"
-    CONTRIB = "cran.r-project.org/src/contrib"
-
-
-    # Helper functions
-    def _check_source(source):
-        """Check if a source has a cran url"""
-        if source and "url" in source:
-            return MIRROR in source["url"] or CONTRIB in source["url"]
-        return False
-
-    def _check_list_of_sources(sources):
-        """Check if a list of sources has a cran url"""
-        for source in sources:
-            if _check_source(source):
-                return True
-        return False
-
-    def _check_source_or_list_of_sources(branch):
-        """Check if a branch of a conditional has a cran url
-        which can again be a source or a list of sources
-        """
-        if branch:
-            if isinstance(branch, dict) and "url" in branch:
-                return _check_source(branch)
-            if isinstance(branch, list):
-                return _check_list_of_sources(branch)
-
-    def _check_conditional(then, elze):
-        """Check if a conditional has a cran url"""
-        if then:
-            # Check the then branch of the conditional
-            return _check_source_or_list_of_sources(then)
-        if elze:
-            # Check the else branch of the conditional
-            return _check_source_or_list_of_sources(elze)
-        return False
-
-    def _check_source_or_conditional(source):
-        """Check if a source has a cran url or if it is a conditional that may contain a cran url"""
-        if _check_source(source):
-            return True
-        return _check_conditional(source.get("then"), source.get("else"))
-
     if not os.path.exists(recipe_location):
         return False
     try:
         with open("recipe/recipe.yaml", "r") as file:
             recipe = yaml.load(file)
-            # Check for top-level source attribute(s)
-            if "source" in recipe:
-                sources = yaml["source"]
-                if isinstance(sources, dict):
-                    # Can only be a source or a conditional
-                    return _check_source_or_conditional(sources)
-                elif isinstance(sources, list):
-                    for source in sources:
-                        # A list that can contain both direct sources and conditionals
-                        if _check_source_or_conditional(source):
-                            return True
-            # There can also be outputs that produce sources and no top level sources
-            # but I think this is also ignored in the `meta.yaml` case, so ignoring it here as well
+            # This gets all 'url' type sources for the rattler-build recipe
+            urls = get_all_url_sources(recipe)
+            for url in urls:
+                if MIRROR in url or CONTRIB in url:
+                    return True
+
     except Exception as e:
         return False
 

--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -37,14 +37,21 @@ class TeamsCleanup(Migrator):
 
         keep_lines = []
         skip = True
+        # First check for `meta.yaml`
         with open("recipe/meta.yaml", "r") as fp:
             for line in fp.readlines():
                 if line.startswith("extra:"):
                     skip = False
                 if not skip:
                     keep_lines.append(line)
-        meta = DummyMeta("".join(keep_lines))
 
+        # Check for recipe.yaml instead
+        if not keep_lines:
+            # Because `rattler_build` recipes are valid yaml
+            # we can just use the whole file
+            with open("recipe/recipe.yaml") as fp:
+                keep_lines = fp.readlines()
+        meta = DummyMeta("".join(keep_lines))
         (
             current_maintainers,
             prev_maintainers,

--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -37,8 +37,10 @@ class TeamsCleanup(Migrator):
 
         keep_lines = []
         skip = True
+        has_meta_yaml = False
         # First check for `meta.yaml`
         with open("recipe/meta.yaml", "r") as fp:
+            has_meta_yaml = True
             for line in fp.readlines():
                 if line.startswith("extra:"):
                     skip = False
@@ -46,7 +48,7 @@ class TeamsCleanup(Migrator):
                     keep_lines.append(line)
 
         # Check for recipe.yaml instead
-        if not keep_lines:
+        if not has_meta_yaml:
             # Because `rattler_build` recipes are valid yaml
             # we can just use the whole file
             with open("recipe/recipe.yaml") as fp:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ ruamel.yaml.jinja2
 flake8
 conda-smithy
 conda-build
-rattler-build
+rattler-build-conda-compat

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ruamel.yaml.jinja2
 flake8
 conda-smithy
 conda-build
+rattler-build


### PR DESCRIPTION
This PR adds support for `rattler-build` recieps for migrations. I've searched across files for usages of `meta.yaml` and have tried to make the changes to support `recipe.yaml` as well.

* `__main__.py` I think I only need to add it so it runs for `recipe.yaml`
* `cfep13_tokens_and_config.py`: This seems to be one of the bigger migrations, we have conda build compatible function that returns a list of metadata's that I've used directly.
* `r_automerge.py`:
  * I've pulled code into the [`rattler-conda-build-compat`](https://github.com/conda-forge/rattler-build-conda-compat-feedstock) library, for the `_has_cran_url_rattler_build`, see the code here: https://github.com/nichmor/rattler-build-conda-compat/blob/4ebdfc13fb5c122cfeb1b9d73babaf77a825017f/src/rattler_build_conda_compat/recipe_sources.py#L13-L50
and the corresponding test here: https://github.com/nichmor/rattler-build-conda-compat/blob/main/tests/test_recipe_sources.py
  * I've added the rest of the code to include the checks for `recipe.yaml` as well
* `teams_cleanup.py` because the `recipe.yaml` is entirely valid yaml and the we have a similar `extra` section I just pass the complete yaml file.
* `requirements.txt` I added the library `rattler-build-conda-compat` to the requirments.

**Is there anything that I've missed so far?**

---

I could use help with the following below, what is the way of testing this?

- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
