### PR TITLE
feat: update lower bound on compat, for 3.8 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ ruamel.yaml.jinja2
 flake8
 conda-smithy
 conda-build
-rattler-build-conda-compat>=0.2.1
+rattler-build-conda-compat>=0.2.2


### PR DESCRIPTION
Increase to `0.2.2` which introduces python3.8 compatibility.
