### PR TITLE
fix: raise error after output collected

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -89,18 +89,15 @@ def pushd(new_dir):
 
 
 def _run_git_command(args, check=True):
-    try:
-        s = subprocess.run(
-            ["git"] + args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=check,
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"    ERROR: {s.stdout.decode('utf-8')}", flush=True)
-        raise e
+    s = subprocess.run(
+        ["git"] + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
     if s.returncode != 0:
         print(f"    ERROR: {s.stdout.decode('utf-8')}", flush=True)
+    if check:
+        s.check_returncode()
     return s.returncode == 0, s.stdout.decode("utf-8")
 
 


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.
