### PR TITLE
fix: use admin token for push

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -60,6 +60,7 @@ jobs:
           run-admin-migrations
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_PUSH_TOKEN: ${{ steps.CF_ADMIN_GITHUB_TOKEN }}
           DRONE_TOKEN: ${{ secrets.DRONE_TOKEN }}
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
           TRAVIS_TOKEN_A: ${{ secrets.CF_LINTER_TRAVIS_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,7 @@ jobs:
           run-admin-migrations
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_PUSH_TOKEN: ${{ steps.CF_ADMIN_GITHUB_TOKEN }}
           DRONE_TOKEN: ${{ secrets.DRONE_TOKEN }}
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
           TRAVIS_TOKEN_A: ${{ secrets.CF_LINTER_TRAVIS_TOKEN }}

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -206,7 +206,7 @@ def _commit_data():
             "--push",
             "origin",
             "https://x-access-token:%s@github.com/"
-            "conda-forge/admin-migrations.git" % os.environ["GITHUB_TOKEN"],
+            "conda-forge/admin-migrations.git" % os.environ["GITHUB_PUSH_TOKEN"],
         ]
     )
     _run_git_command(["push", "--quiet"])


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.

This PR fixes pushes by using an admin token.
