### PR TITLE
fix: use token in checkout to bypass

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -24,6 +24,8 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          token: ${{ steps.CF_ADMIN_GITHUB_TOKEN }}
 
       - uses: mamba-org/setup-micromamba@617811f69075e3fd3ae68ca64220ad065877f246
         with:
@@ -58,7 +60,6 @@ jobs:
           run-admin-migrations
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          GITHUB_PUSH_TOKEN: ${{ steps.CF_ADMIN_GITHUB_TOKEN }}
           DRONE_TOKEN: ${{ secrets.DRONE_TOKEN }}
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
           TRAVIS_TOKEN_A: ${{ secrets.CF_LINTER_TRAVIS_TOKEN }}

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -199,16 +199,6 @@ def _commit_data():
     _run_git_command(["stash", "pop"])
     _run_git_command(["add", "data/*.json"])
     _run_git_command(["commit", "-m", "[ci skip] data for admin migration run"])
-    _run_git_command(
-        [
-            "remote",
-            "set-url",
-            "--push",
-            "origin",
-            "https://x-access-token:%s@github.com/"
-            "conda-forge/admin-migrations.git" % os.environ["GITHUB_PUSH_TOKEN"],
-        ]
-    )
     _run_git_command(["push", "--quiet"])
 
 


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.

hopefully this [SO post](https://stackoverflow.com/questions/69263843/how-to-push-to-protected-main-branches-in-a-github-action) works...
