### PR TITLE
feat: add automerge and webservices workflow removal

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -19,9 +19,9 @@ from admin_migrations.defaults import DEBUG, MAX_MIGRATE, MAX_SECONDS, MAX_WORKE
 # commented ones are finished or not used
 from admin_migrations.migrators import (
     BranchProtection,
-    CondaForgeAutomergeUpdate,
     CondaForgeYAMLTest,
     RAutomerge,
+    RemoveAutomergeAndRerender,
     # RotateCFStagingToken,
     # RotateFeedstockToken,
     # CondaForgeMasterToMain,
@@ -373,7 +373,7 @@ def main():
         # CondaForgeMasterToMain(),  # this one always goes first since it makes extra
         #                            # commits etc
         # FeedstocksServiceUpdate(),
-        CondaForgeAutomergeUpdate(),
+        # CondaForgeAutomergeUpdate(),
         BranchProtection(),
         # DotConda(),
         # CondaForgeGHAWithMain(),
@@ -390,6 +390,7 @@ def main():
         # AutomergeAndRerender(),
         # CFEP13TurnOff(),
         # AutomergeAndBotRerunLabels(),
+        RemoveAutomergeAndRerender(),
     ]
     print(" ", flush=True)
 

--- a/admin_migrations/migrators/__init__.py
+++ b/admin_migrations/migrators/__init__.py
@@ -17,3 +17,4 @@ from .feedstocks_service_update import FeedstocksServiceUpdate
 from .dot_conda import DotConda
 from .conda_forge_yml_test import CondaForgeYAMLTest
 from .branch_protection import BranchProtection
+from .remove_automerge_and_rerender import RemoveAutomergeAndRerender

--- a/admin_migrations/migrators/remove_automerge_and_rerender.py
+++ b/admin_migrations/migrators/remove_automerge_and_rerender.py
@@ -26,19 +26,19 @@ class RemoveAutomergeAndRerender(Migrator):
                     )
                     make_commit = True
 
-        repo_name = "%s-feedstock" % feedstock
-        gh_repo = ORG.get_repo(repo_name)
-        for fname in ["automerge.yml", "webservices.yml"]:
-            workflow = gh_repo.get_workflow(fname)
-            # /repos/OWNER/REPO/actions/workflows/WORKFLOW_ID/disable
-            url = gh_repo.url + f"/actions/workflows/{workflow.id}/disable"
-            try:
-                gh_repo._requester.requestJsonAndCheck(
-                    "PUT",
-                    url,
-                )
-            except github.GithubException:
-                pass
+        # repo_name = "%s-feedstock" % feedstock
+        # gh_repo = ORG.get_repo(repo_name)
+        # for fname in ["automerge.yml", "webservices.yml"]:
+        #     workflow = gh_repo.get_workflow(fname)
+        #     # /repos/OWNER/REPO/actions/workflows/WORKFLOW_ID/disable
+        #     url = gh_repo.url + f"/actions/workflows/{workflow.id}/disable"
+        #     try:
+        #         gh_repo._requester.requestJsonAndCheck(
+        #             "PUT",
+        #             url,
+        #         )
+        #     except github.GithubException:
+        #         pass
 
         # did it work, commit, made API calls
         return True, make_commit, True

--- a/admin_migrations/migrators/remove_automerge_and_rerender.py
+++ b/admin_migrations/migrators/remove_automerge_and_rerender.py
@@ -41,4 +41,4 @@ class RemoveAutomergeAndRerender(Migrator):
         #         pass
 
         # did it work, commit, made API calls
-        return True, make_commit, True
+        return True, make_commit, False

--- a/admin_migrations/migrators/remove_automerge_and_rerender.py
+++ b/admin_migrations/migrators/remove_automerge_and_rerender.py
@@ -11,10 +11,10 @@ ORG = GH.get_organization("conda-forge")
 
 class RemoveAutomergeAndRerender(Migrator):
     def migrate(self, feedstock, branch):
+        make_commit = False
         if os.path.exists(".github/workflows/automerge.yml") or os.path.exists(
             ".github/workflows/webservices.yml"
         ):
-            make_commit = False
             for fname in [
                 ".github/workflows/automerge.yml",
                 ".github/workflows/webservices.yml",

--- a/admin_migrations/migrators/remove_automerge_and_rerender.py
+++ b/admin_migrations/migrators/remove_automerge_and_rerender.py
@@ -32,10 +32,13 @@ class RemoveAutomergeAndRerender(Migrator):
             workflow = gh_repo.get_workflow(fname)
             # /repos/OWNER/REPO/actions/workflows/WORKFLOW_ID/disable
             url = gh_repo.url + f"/actions/workflows/{workflow.id}/disable"
-            gh_repo._requester.requestJsonAndCheck(
-                "PUT",
-                url,
-            )
+            try:
+                gh_repo._requester.requestJsonAndCheck(
+                    "PUT",
+                    url,
+                )
+            except github.GithubException:
+                pass
 
         # did it work, commit, made API calls
         return True, make_commit, True

--- a/admin_migrations/migrators/remove_automerge_and_rerender.py
+++ b/admin_migrations/migrators/remove_automerge_and_rerender.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+
+import github
+
+from .base import Migrator
+
+GH = github.Github(os.environ["GITHUB_TOKEN"])
+ORG = GH.get_organization("conda-forge")
+
+
+class RemoveAutomergeAndRerender(Migrator):
+    def migrate(self, feedstock, branch):
+        if os.path.exists(".github/workflows/automerge.yml") or os.path.exists(
+            ".github/workflows/webservices.yml"
+        ):
+            make_commit = False
+            for fname in [
+                ".github/workflows/automerge.yml",
+                ".github/workflows/webservices.yml",
+            ]:
+                if os.path.exists(fname):
+                    subprocess.run(
+                        ["git", "rm", "-f", fname],
+                        check=True,
+                    )
+                    make_commit = True
+
+        repo_name = "%s-feedstock" % feedstock
+        gh_repo = ORG.get_repo(repo_name)
+        for fname in ["automerge.yml", "webservices.yml"]:
+            workflow = gh_repo.get_workflow(fname)
+            # /repos/OWNER/REPO/actions/workflows/WORKFLOW_ID/disable
+            url = gh_repo.url + f"/actions/workflows/{workflow.id}/disable"
+            gh_repo._requester.requestJsonAndCheck(
+                "PUT",
+                url,
+            )
+
+        # did it work, commit, made API calls
+        return True, make_commit, True

--- a/admin_migrations/migrators/remove_automerge_and_rerender.py
+++ b/admin_migrations/migrators/remove_automerge_and_rerender.py
@@ -26,19 +26,23 @@ class RemoveAutomergeAndRerender(Migrator):
                     )
                     make_commit = True
 
-        # repo_name = "%s-feedstock" % feedstock
-        # gh_repo = ORG.get_repo(repo_name)
-        # for fname in ["automerge.yml", "webservices.yml"]:
-        #     workflow = gh_repo.get_workflow(fname)
-        #     # /repos/OWNER/REPO/actions/workflows/WORKFLOW_ID/disable
-        #     url = gh_repo.url + f"/actions/workflows/{workflow.id}/disable"
-        #     try:
-        #         gh_repo._requester.requestJsonAndCheck(
-        #             "PUT",
-        #             url,
-        #         )
-        #     except github.GithubException:
-        #         pass
+        made_api_calls = False
+        # if branch in ["main", "master"]:
+        #     repo_name = "%s-feedstock" % feedstock
+        #     gh_repo = ORG.get_repo(repo_name)
+        #     for fname in ["automerge.yml", "webservices.yml"]:
+        #         workflow = gh_repo.get_workflow(fname)
+        #         # /repos/OWNER/REPO/actions/workflows/WORKFLOW_ID/disable
+        #         url = gh_repo.url + f"/actions/workflows/{workflow.id}/disable"
+        #         try:
+        #             gh_repo._requester.requestJsonAndCheck(
+        #                 "PUT",
+        #                 url,
+        #             )
+        #         except github.GithubException:
+        #             pass
+
+        #     made_api_calls = True
 
         # did it work, commit, made API calls
-        return True, make_commit, False
+        return True, make_commit, made_api_calls


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.
