### PR TITLE
fix: only say made api calls if actually did

### DIFF
--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -56,5 +56,7 @@ class TeamsCleanup(Migrator):
             rsp.raise_for_status()
             print("    updated team", flush=True)
 
-        # migration done, make a commit, lots of API calls
-        return False, False, True
+            # migration done, make a commit, lots of API calls
+            return False, False, True
+        else:
+            return False, False, False


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.
