### PR TITLE
add 2026_04_21 recipe-maintainers cleanup script

### DIFF
--- a/scripts/2026_04_21_freed_maintainer_cleanup/README.md
+++ b/scripts/2026_04_21_freed_maintainer_cleanup/README.md
@@ -1,0 +1,49 @@
+# Recipe maintainer cleanup (2026-04-21)
+
+A sweep of every conda-forge feedstock's recipe turned up 71 maintainer
+logins that no longer resolve on GitHub (`GET /users/<login>` → 404)
+across 103 feedstocks.
+
+This directory holds a one-shot local cleanup: for every affected feedstock
+we either
+
+- replace the missing login with the maintainer's confirmed current login
+  (where the rename could be established by cross-referencing staged-recipes
+  git author metadata or PR authorship), or
+- remove the missing login from the list (where no current handle could be
+  recovered).
+
+## Running
+
+Requires `git`, Python 3.9+, and `GITHUB_TOKEN` with push access to
+`conda-forge/*-feedstock` repos (i.e. conda-forge org member with
+feedstock-maintainer privileges).
+
+```bash
+# dry run (prints the diff it would apply; makes no changes)
+python cleanup.py
+
+# actually commit and push
+python cleanup.py --commit
+```
+
+Behaviour:
+
+- clones each feedstock shallow to `/tmp`
+- edits only the single `- <freed_login>` line in `extra.recipe-maintainers`
+- commits with `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` so CI is
+  suppressed per admin-migrations guidelines
+- pushes to the feedstock's default branch
+- skips already-fixed feedstocks idempotently (so the script is resumable)
+- appends each processed feedstock to `done.txt`
+
+## Input
+
+`mapping.tsv` — three columns: `feedstock`, `freed_login`, `new_login`.
+Leave `new_login` empty to remove the freed login without replacement.
+
+## Audit trail
+
+Each commit is reproducible from `mapping.tsv`; the source data
+(`freed.txt`, `exposed_feedstocks.tsv`, `rename_candidates.tsv`) used to
+derive the mapping lives in the triage repo, not here.

--- a/scripts/2026_04_21_freed_maintainer_cleanup/cleanup.py
+++ b/scripts/2026_04_21_freed_maintainer_cleanup/cleanup.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Replace or remove freed maintainer logins in conda-forge feedstocks.
+
+Input: mapping.tsv with columns feedstock, freed_login, new_login (empty = remove).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MAPPING = HERE / "mapping.tsv"
+DONE = HERE / "done.txt"
+COMMIT_MESSAGE = (
+    "[ci skip] [skip ci] [cf admin skip] ***NO_CI*** update recipe-maintainers"
+)
+RECIPE_CANDIDATES = ("recipe/meta.yaml", "recipe/recipe.yaml")
+DELAY_SECONDS = 3
+
+
+def run(
+    cmd: list[str], cwd: Path | None = None, check: bool = True
+) -> subprocess.CompletedProcess:
+    r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise RuntimeError(
+            f"cmd failed: {' '.join(cmd)}\nstdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+    return r
+
+
+def find_recipe(repo: Path) -> Path | None:
+    for rel in RECIPE_CANDIDATES:
+        p = repo / rel
+        if p.exists():
+            return p
+    return None
+
+
+def edit_recipe(text: str, freed: str, new_login: str) -> tuple[str, bool]:
+    """Replace or remove a single maintainer line. Returns (new_text, changed)."""
+    # Match the specific bullet in the recipe-maintainers list. The regex
+    # requires we are inside the recipe-maintainers block (look-behind across
+    # a few lines) and matches the single target login line, preserving any
+    # surrounding list items.
+    pat = re.compile(
+        r"""(?P<prefix>^[ \t]+recipe[-_]maintainers:[^\n]*\n
+            (?:[ \t]+-[ \t]*[^\n]*\n|[ \t]*\n)*?)
+            (?P<line>[ \t]+-[ \t]*["']?"""
+        + re.escape(freed)
+        + r"""["']?[ \t]*(?:\#[^\n]*)?\n)""",
+        re.MULTILINE | re.VERBOSE,
+    )
+    m = pat.search(text)
+    if not m:
+        return text, False
+
+    if new_login:
+        # Preserve indentation and any trailing comment pattern by replacing
+        # only the login token; simpler to rewrite the whole line.
+        indent = re.match(r"^[ \t]+-[ \t]*", m.group("line")).group(0)
+        replacement = f"{indent}{new_login}\n"
+    else:
+        replacement = ""
+
+    new_text = text[: m.start("line")] + replacement + text[m.end("line") :]
+    return new_text, True
+
+
+def ensure_repo_clone(feedstock: str, token: str, workdir: Path) -> Path:
+    url = f"https://x-access-token:{token}@github.com/conda-forge/{feedstock}.git"
+    dest = workdir / feedstock
+    run(["git", "clone", "--depth=1", "--quiet", url, str(dest)])
+    return dest
+
+
+def default_branch(repo: Path) -> str:
+    r = run(["git", "symbolic-ref", "--short", "HEAD"], cwd=repo)
+    return r.stdout.strip()
+
+
+def already_done(feedstock: str, freed: str) -> bool:
+    if not DONE.exists():
+        return False
+    for line in DONE.read_text().splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0] == feedstock and parts[1] == freed:
+            return True
+    return False
+
+
+def record_done(feedstock: str, freed: str, result: str) -> None:
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    with DONE.open("a") as f:
+        f.write(f"{feedstock}\t{freed}\t{result}\t{ts}\n")
+
+
+def process_one(row: dict, token: str, commit: bool, workdir: Path) -> str:
+    feedstock = row["feedstock"]
+    freed = row["freed_login"]
+    new_login = row.get("new_login", "").strip()
+
+    repo = ensure_repo_clone(feedstock, token, workdir)
+    recipe = find_recipe(repo)
+    if recipe is None:
+        return "no_recipe"
+
+    text = recipe.read_text(encoding="utf-8")
+    new_text, changed = edit_recipe(text, freed, new_login)
+    if not changed:
+        return "already_clean"
+
+    recipe.write_text(new_text, encoding="utf-8")
+
+    diff = run(["git", "diff", "--", str(recipe.relative_to(repo))], cwd=repo).stdout
+    print(diff)
+
+    if not commit:
+        return "dry_run"
+
+    # sanity: the diff must touch exactly one line in the recipe
+    added = sum(
+        1
+        for line in diff.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    )
+    removed = sum(
+        1
+        for line in diff.splitlines()
+        if line.startswith("-") and not line.startswith("---")
+    )
+    expected = (1, 1) if new_login else (0, 1)
+    if (added, removed) != expected:
+        return f"unexpected_diff(+{added}/-{removed})"
+
+    run(["git", "add", str(recipe.relative_to(repo))], cwd=repo)
+    run(
+        [
+            "git",
+            "-c",
+            "user.email=conda-forge-admin@conda-forge.org",
+            "-c",
+            "user.name=conda-forge-admin",
+            "commit",
+            "-m",
+            COMMIT_MESSAGE,
+        ],
+        cwd=repo,
+    )
+
+    branch = default_branch(repo)
+    run(["git", "push", "origin", branch], cwd=repo)
+    return "pushed"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--commit", action="store_true", help="actually commit and push")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--only", default=None, help="process only this feedstock slug")
+    args = ap.parse_args()
+
+    token = (
+        os.environ.get("GITHUB_TOKEN")
+        or subprocess.run(
+            ["gh", "auth", "token"], capture_output=True, text=True
+        ).stdout.strip()
+    )
+    if not token:
+        print("need GITHUB_TOKEN or `gh auth login`", file=sys.stderr)
+        return 2
+
+    if not MAPPING.exists():
+        print(f"missing {MAPPING}", file=sys.stderr)
+        return 2
+
+    rows: list[dict] = []
+    with MAPPING.open() as f:
+        for row in csv.DictReader(f, delimiter="\t"):
+            if args.only and row["feedstock"] != args.only:
+                continue
+            rows.append(row)
+
+    if args.limit:
+        rows = rows[: args.limit]
+
+    with tempfile.TemporaryDirectory(prefix="freed-maint-") as tmp:
+        workdir = Path(tmp)
+        counts: dict[str, int] = {}
+        for i, row in enumerate(rows, 1):
+            feedstock = row["feedstock"]
+            freed = row["freed_login"]
+            new = row.get("new_login", "").strip()
+            action = "remove" if not new else f"rename→{new}"
+            print(f"\n[{i}/{len(rows)}] {feedstock}  {freed} ({action})")
+
+            if already_done(feedstock, freed):
+                print("  already done, skipping")
+                counts["already_done"] = counts.get("already_done", 0) + 1
+                continue
+
+            try:
+                result = process_one(row, token, args.commit, workdir)
+            except Exception as e:
+                result = f"error:{type(e).__name__}:{e}"
+                print(f"  {result}")
+
+            counts[result] = counts.get(result, 0) + 1
+            if args.commit:
+                record_done(feedstock, freed, result)
+
+            # rate limit after successful push
+            if result == "pushed" and i < len(rows):
+                time.sleep(DELAY_SECONDS)
+
+            # tidy the clone
+            slug_dir = workdir / feedstock
+            if slug_dir.exists():
+                shutil.rmtree(slug_dir, ignore_errors=True)
+
+    print("\nsummary:")
+    for k, v in sorted(counts.items()):
+        print(f"  {k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/2026_04_21_freed_maintainer_cleanup/mapping.tsv
+++ b/scripts/2026_04_21_freed_maintainer_cleanup/mapping.tsv
@@ -1,0 +1,104 @@
+feedstock	freed_login	new_login
+koalas-feedstock	xinrong-databricks	
+pyomo.extras-feedstock	Juanlu001	astrojuanlu
+datefinder-feedstock	melonhead901	
+yellowbrick-feedstock	melonhead901	
+entrypoint2-feedstock	melonhead901	
+puma-feedstock	fsemerar	fedesemeraro
+python-patch-feedstock	windelbouwmanbosch	
+pyhum-feedstock	dbuscombe-usgs	
+tsne-feedstock	WiscEvan	evanroyrees
+aim-feedstock	gorarakelyan	
+pyweed-feedstock	adam-iris	adam-earthscope
+speedtest-cli-feedstock	gacallea	
+zbarlight-feedstock	kdmurray91	kdm9
+pytorch-model-summary-feedstock	fishyai	fishbotics
+similaritymeasures-feedstock	melonhead901	
+r-crf-feedstock	Chris-Lowe-Integrity	
+ferret_datasets-feedstock	josborne-noaa	
+pycaret-feedstock	melonhead901	
+edrixs-feedstock	thomashopkins32	
+r-kfas-feedstock	melonhead901	
+redo-feedstock	mozbhearsum	
+esmvaltool-python-feedstock	jvegasbsc	
+r-loader-feedstock	mor427unican	
+jproperties-feedstock	melonhead901	
+chfem-feedstock	fsemerar	fedesemeraro
+pymove-feedstock	flych3r	mxaviersmp
+unrar-feedstock	melonhead901	
+opacus-feedstock	ffuuugor	
+rauth-feedstock	tizzir	
+modflowapi-feedstock	jdhughes-usgs	jdhughes-dev
+sqlobject-feedstock	windelbouwmanbosch	
+sphericaltexture-feedstock	oanegros	
+planetaryimage-feedstock	pbvarga1	
+epiweeks4cf-feedstock	jdhughes-usgs	jdhughes-dev
+pyfoomb-feedstock	Beaker034	
+waybackpy-feedstock	labriunesp	
+hera-workflows-feedstock	sagiahrac	
+sisppeo-feedstock	pierre-manchon	
+asyncinit-feedstock	vladsaveliev	vladsavelyev
+pytrack-feedstock	mtortora-ai	
+pyemojify-feedstock	hellothisisMatt	
+entropy-feedstock	PackageCondaDataScience	
+pyet-feedstock	savente93	
+genv-feedstock	razrotenberg	
+gis-utils-feedstock	jdhughes-usgs	jdhughes-dev
+blackboxauditing-feedstock	pavelgrib	
+modflow-export-feedstock	jdhughes-usgs	jdhughes-dev
+compas_cloud-feedstock	brgcode	tomvanmele
+tjpcov-feedstock	mattkwiecien	
+watex-feedstock	WEgeophysics	earthai-tech
+pylbl-feedstock	menzel-gfdl	
+pettingzoo-feedstock	melonhead901	
+jupyterlab_genv-feedstock	razrotenberg	
+hyram-feedstock	bdehrha	
+factor-analyzer-feedstock	melonhead901	
+pymove-osmnx-feedstock	flych3r	mxaviersmp
+census-parquet-feedstock	drstewart19	dylanrstewart
+predictr-feedstock	melonhead901	
+amazon-codewhisperer-jupyterlab-ext-feedstock	dhanainme	
+kaggle-environments-feedstock	melonhead901	
+quantizer-feedstock	ulrichtsblr	
+dasbus-feedstock	Stig124	
+lofo-importance-feedstock	melonhead901	
+simple-gcp-object-downloader-feedstock	madhur-ob	
+metaflow-stubs-feedstock	madhur-ob	
+chessnut-feedstock	melonhead901	
+ml4xcube-feedstock	Julia310	
+jwskate-feedstock	melonhead901	
+timescoring-feedstock	danjjl	
+requests_oauth2client-feedstock	melonhead901	
+fastreg-feedstock	corentinlelannier	
+defillama-curl-feedstock	the-praxs	
+binapy-feedstock	melonhead901	
+napari-file-watcher-feedstock	kasasxav	
+nodimo-feedstock	rodrigopcastro018	
+simple-azure-blob-downloader-feedstock	madhur-ob	
+oneworld-feedstock	taguilar	
+piano_fingering-feedstock	betofraus	jafraustro
+ptac-feedstock	serrayos	
+pds.api-client-feedstock	collinss-jpl	sdcolli1
+tangods-mcmax-feedstock	Bartarian	A-Barta
+xymol-feedstock	hhaootian	
+pds.peppi-feedstock	collinss-jpl	sdcolli1
+rocketpy-feedstock	LUCKIN13	
+aicsimageio-feedstock	SeanLeRoy	
+caterva-feedstock	aleix11alcacer	
+adept-feedstock	arghdos	
+bakelite-feedstock	brendan0powers	
+aws-amicleaner-feedstock	ct-hbk	ctovar-hbk
+awxkit-feedstock	gacallea	
+aim-ui-feedstock	gorarakelyan	
+aimrocks-feedstock	gorarakelyan	
+hopcroftkarp-feedstock	henrik227	
+brainbox-ibl-feedstock	jaib1	
+wand-feedstock	melonhead901	
+aws-amicleaner-feedstock	nm-hbk	ctovar-hbk
+hoomd-dlext-feedstock	pabloferz	
+django-modelcluster-feedstock	rxm7708	
+hydromt-feedstock	savente93	
+bhklab-project-template-feedstock	strixy16	
+pyiron_dft-feedstock	sudarsan1989	
+pyiron_example_job-feedstock	sudarsan1989	
+caustics-feedstock	uwcdc	

--- a/scripts/2026_04_21_freed_maintainer_cleanup/mapping.tsv
+++ b/scripts/2026_04_21_freed_maintainer_cleanup/mapping.tsv
@@ -1,104 +1,104 @@
 feedstock	freed_login	new_login
-koalas-feedstock	xinrong-databricks	
-pyomo.extras-feedstock	Juanlu001	astrojuanlu
-datefinder-feedstock	melonhead901	
-yellowbrick-feedstock	melonhead901	
-entrypoint2-feedstock	melonhead901	
-puma-feedstock	fsemerar	fedesemeraro
-python-patch-feedstock	windelbouwmanbosch	
-pyhum-feedstock	dbuscombe-usgs	
-tsne-feedstock	WiscEvan	evanroyrees
-aim-feedstock	gorarakelyan	
-pyweed-feedstock	adam-iris	adam-earthscope
-speedtest-cli-feedstock	gacallea	
-zbarlight-feedstock	kdmurray91	kdm9
-pytorch-model-summary-feedstock	fishyai	fishbotics
-similaritymeasures-feedstock	melonhead901	
-r-crf-feedstock	Chris-Lowe-Integrity	
-ferret_datasets-feedstock	josborne-noaa	
-pycaret-feedstock	melonhead901	
-edrixs-feedstock	thomashopkins32	
-r-kfas-feedstock	melonhead901	
-redo-feedstock	mozbhearsum	
-esmvaltool-python-feedstock	jvegasbsc	
-r-loader-feedstock	mor427unican	
-jproperties-feedstock	melonhead901	
-chfem-feedstock	fsemerar	fedesemeraro
-pymove-feedstock	flych3r	mxaviersmp
-unrar-feedstock	melonhead901	
-opacus-feedstock	ffuuugor	
-rauth-feedstock	tizzir	
-modflowapi-feedstock	jdhughes-usgs	jdhughes-dev
-sqlobject-feedstock	windelbouwmanbosch	
-sphericaltexture-feedstock	oanegros	
-planetaryimage-feedstock	pbvarga1	
-epiweeks4cf-feedstock	jdhughes-usgs	jdhughes-dev
-pyfoomb-feedstock	Beaker034	
-waybackpy-feedstock	labriunesp	
-hera-workflows-feedstock	sagiahrac	
-sisppeo-feedstock	pierre-manchon	
-asyncinit-feedstock	vladsaveliev	vladsavelyev
-pytrack-feedstock	mtortora-ai	
-pyemojify-feedstock	hellothisisMatt	
-entropy-feedstock	PackageCondaDataScience	
-pyet-feedstock	savente93	
-genv-feedstock	razrotenberg	
-gis-utils-feedstock	jdhughes-usgs	jdhughes-dev
-blackboxauditing-feedstock	pavelgrib	
-modflow-export-feedstock	jdhughes-usgs	jdhughes-dev
-compas_cloud-feedstock	brgcode	tomvanmele
-tjpcov-feedstock	mattkwiecien	
-watex-feedstock	WEgeophysics	earthai-tech
-pylbl-feedstock	menzel-gfdl	
-pettingzoo-feedstock	melonhead901	
-jupyterlab_genv-feedstock	razrotenberg	
-hyram-feedstock	bdehrha	
-factor-analyzer-feedstock	melonhead901	
-pymove-osmnx-feedstock	flych3r	mxaviersmp
-census-parquet-feedstock	drstewart19	dylanrstewart
-predictr-feedstock	melonhead901	
-amazon-codewhisperer-jupyterlab-ext-feedstock	dhanainme	
-kaggle-environments-feedstock	melonhead901	
-quantizer-feedstock	ulrichtsblr	
-dasbus-feedstock	Stig124	
-lofo-importance-feedstock	melonhead901	
-simple-gcp-object-downloader-feedstock	madhur-ob	
-metaflow-stubs-feedstock	madhur-ob	
-chessnut-feedstock	melonhead901	
-ml4xcube-feedstock	Julia310	
-jwskate-feedstock	melonhead901	
-timescoring-feedstock	danjjl	
-requests_oauth2client-feedstock	melonhead901	
-fastreg-feedstock	corentinlelannier	
-defillama-curl-feedstock	the-praxs	
-binapy-feedstock	melonhead901	
-napari-file-watcher-feedstock	kasasxav	
-nodimo-feedstock	rodrigopcastro018	
-simple-azure-blob-downloader-feedstock	madhur-ob	
-oneworld-feedstock	taguilar	
-piano_fingering-feedstock	betofraus	jafraustro
-ptac-feedstock	serrayos	
-pds.api-client-feedstock	collinss-jpl	sdcolli1
-tangods-mcmax-feedstock	Bartarian	A-Barta
-xymol-feedstock	hhaootian	
-pds.peppi-feedstock	collinss-jpl	sdcolli1
-rocketpy-feedstock	LUCKIN13	
-aicsimageio-feedstock	SeanLeRoy	
-caterva-feedstock	aleix11alcacer	
 adept-feedstock	arghdos	
-bakelite-feedstock	brendan0powers	
-aws-amicleaner-feedstock	ct-hbk	ctovar-hbk
-awxkit-feedstock	gacallea	
+aicsimageio-feedstock	SeanLeRoy	
+aim-feedstock	gorarakelyan	
 aim-ui-feedstock	gorarakelyan	
 aimrocks-feedstock	gorarakelyan	
-hopcroftkarp-feedstock	henrik227	
-brainbox-ibl-feedstock	jaib1	
-wand-feedstock	melonhead901	
+amazon-codewhisperer-jupyterlab-ext-feedstock	dhanainme	
+asyncinit-feedstock	vladsaveliev	vladsavelyev
+aws-amicleaner-feedstock	ct-hbk	ctovar-hbk
 aws-amicleaner-feedstock	nm-hbk	ctovar-hbk
-hoomd-dlext-feedstock	pabloferz	
-django-modelcluster-feedstock	rxm7708	
-hydromt-feedstock	savente93	
+awxkit-feedstock	gacallea	
+bakelite-feedstock	brendan0powers	
 bhklab-project-template-feedstock	strixy16	
+binapy-feedstock	melonhead901	
+blackboxauditing-feedstock	pavelgrib	
+brainbox-ibl-feedstock	jaib1	
+caterva-feedstock	aleix11alcacer	
+caustics-feedstock	uwcdc	
+census-parquet-feedstock	drstewart19	dylanrstewart
+chessnut-feedstock	melonhead901	
+chfem-feedstock	fsemerar	fedesemeraro
+compas_cloud-feedstock	brgcode	tomvanmele
+dasbus-feedstock	Stig124	
+datefinder-feedstock	melonhead901	
+defillama-curl-feedstock	the-praxs	
+django-modelcluster-feedstock	rxm7708	
+edrixs-feedstock	thomashopkins32	
+entropy-feedstock	PackageCondaDataScience	
+entrypoint2-feedstock	melonhead901	
+epiweeks4cf-feedstock	jdhughes-usgs	jdhughes-dev
+esmvaltool-python-feedstock	jvegasbsc	
+factor-analyzer-feedstock	melonhead901	
+fastreg-feedstock	corentinlelannier	
+ferret_datasets-feedstock	josborne-noaa	
+genv-feedstock	razrotenberg	
+gis-utils-feedstock	jdhughes-usgs	jdhughes-dev
+hera-workflows-feedstock	sagiahrac	
+hoomd-dlext-feedstock	pabloferz	
+hopcroftkarp-feedstock	henrik227	
+hydromt-feedstock	savente93	
+hyram-feedstock	bdehrha	
+jproperties-feedstock	melonhead901	
+jupyterlab_genv-feedstock	razrotenberg	
+jwskate-feedstock	melonhead901	
+kaggle-environments-feedstock	melonhead901	
+koalas-feedstock	xinrong-databricks	
+lofo-importance-feedstock	melonhead901	
+metaflow-stubs-feedstock	madhur-ob	
+ml4xcube-feedstock	Julia310	
+modflow-export-feedstock	jdhughes-usgs	jdhughes-dev
+modflowapi-feedstock	jdhughes-usgs	jdhughes-dev
+napari-file-watcher-feedstock	kasasxav	
+nodimo-feedstock	rodrigopcastro018	
+oneworld-feedstock	taguilar	
+opacus-feedstock	ffuuugor	
+pds.api-client-feedstock	collinss-jpl	sdcolli1
+pds.peppi-feedstock	collinss-jpl	sdcolli1
+pettingzoo-feedstock	melonhead901	
+piano_fingering-feedstock	betofraus	jafraustro
+planetaryimage-feedstock	pbvarga1	
+predictr-feedstock	melonhead901	
+ptac-feedstock	serrayos	
+puma-feedstock	fsemerar	fedesemeraro
+pycaret-feedstock	melonhead901	
+pyemojify-feedstock	hellothisisMatt	
+pyet-feedstock	savente93	
+pyfoomb-feedstock	Beaker034	
+pyhum-feedstock	dbuscombe-usgs	
 pyiron_dft-feedstock	sudarsan1989	
 pyiron_example_job-feedstock	sudarsan1989	
-caustics-feedstock	uwcdc	
+pylbl-feedstock	menzel-gfdl	
+pymove-feedstock	flych3r	mxaviersmp
+pymove-osmnx-feedstock	flych3r	mxaviersmp
+pyomo.extras-feedstock	Juanlu001	astrojuanlu
+python-patch-feedstock	windelbouwmanbosch	
+pytorch-model-summary-feedstock	fishyai	fishbotics
+pytrack-feedstock	mtortora-ai	
+pyweed-feedstock	adam-iris	adam-earthscope
+quantizer-feedstock	ulrichtsblr	
+r-crf-feedstock	Chris-Lowe-Integrity	
+r-kfas-feedstock	melonhead901	
+r-loader-feedstock	mor427unican	
+rauth-feedstock	tizzir	
+redo-feedstock	mozbhearsum	
+requests_oauth2client-feedstock	melonhead901	
+rocketpy-feedstock	LUCKIN13	
+similaritymeasures-feedstock	melonhead901	
+simple-azure-blob-downloader-feedstock	madhur-ob	
+simple-gcp-object-downloader-feedstock	madhur-ob	
+sisppeo-feedstock	pierre-manchon	
+speedtest-cli-feedstock	gacallea	
+sphericaltexture-feedstock	oanegros	
+sqlobject-feedstock	windelbouwmanbosch	
+tangods-mcmax-feedstock	Bartarian	A-Barta
+timescoring-feedstock	danjjl	
+tjpcov-feedstock	mattkwiecien	
+tsne-feedstock	WiscEvan	evanroyrees
+unrar-feedstock	melonhead901	
+wand-feedstock	melonhead901	
+watex-feedstock	WEgeophysics	earthai-tech
+waybackpy-feedstock	labriunesp	
+xymol-feedstock	hhaootian	
+yellowbrick-feedstock	melonhead901	
+zbarlight-feedstock	kdmurray91	kdm9


### PR DESCRIPTION
One-shot local cleanup of conda-forge feedstocks whose recipe-maintainers list references a GitHub login that no longer resolves. The script replaces such logins with the maintainer's current login where the rename can be established, and removes them otherwise.

This does not include archived feedstocks.
