### PR TITLE
prod: run longer

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -2,7 +2,7 @@ name: migrate
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 */2 * * *"
   workflow_dispatch: null
 
 concurrency: migrate

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -47,7 +47,7 @@ def _assert_at_0():
         _cfg = yaml.load(fp.read())
     if "schedule" in _cfg["on"]:
         ctab = _cfg["on"]["schedule"][0]["cron"]
-        assert ctab == "0 * * * *", "Wrong cron tab %s for GHA!" % ctab
+        assert ctab == "0 */2 * * *", "Wrong cron tab %s for GHA!" % ctab
 
 
 _assert_at_0()
@@ -151,7 +151,7 @@ def _get_all_feedstocks():
 def _load_feedstock_data():
     curr_hour = datetime.datetime.utcnow().hour
     if (
-        curr_hour % 4 == 0 or not os.path.exists("data/all_feedstocks.json")
+        curr_hour % 6 == 0 or not os.path.exists("data/all_feedstocks.json")
     ) and not DEBUG:
         dt = time.time()
         all_feedstocks = _get_all_feedstocks()

--- a/admin_migrations/defaults.py
+++ b/admin_migrations/defaults.py
@@ -3,11 +3,30 @@ import os
 
 DEBUG = "DEBUG_ADMIN_MIGRATIONS" in os.environ
 
+
+def _compute_max_migrate_minutes():
+    now = datetime.datetime.now(datetime.UTC)
+    if now.hour % 2 == 0:
+        even_hour_offset = 60
+    else:
+        even_hour_offset = 0
+
+    max_mins = even_hour_offset + 60 - now.minute - 6
+
+    if max_mins < 0:
+        max_mins = 0
+
+    if max_mins > 110:
+        max_mins = 110
+
+    return max_mins
+
+
 if DEBUG:
     MAX_MIGRATE = 1
     MAX_SECONDS = 50 * 60
     MAX_WORKERS = 1
 else:
     MAX_MIGRATE = 2000
-    MAX_SECONDS = min(50, max(60 - datetime.datetime.now().minute - 6, 0)) * 60
+    MAX_SECONDS = _compute_max_migrate_minutes() * 60
     MAX_WORKERS = 2


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.

This PR changes the migrations to go for two hours instead of one.