### PR TITLE
prod: fewer processes

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -31,6 +31,7 @@ MIGRATORS = [
     CondaForgeYAMLTest(),
     TeamsCleanup(),
 ]
+N_WORKERS = None
 
 
 @functools.lru_cache(maxsize=1)
@@ -418,6 +419,8 @@ def _render_readme():
 
 
 def main() -> int:
+    global N_WORKERS
+
     print(" ", flush=True)
 
     feedstocks = _load_feedstock_data()
@@ -456,6 +459,8 @@ def main() -> int:
 
     if n_workers > MAX_WORKERS:
         n_workers = MAX_WORKERS
+
+    N_WORKERS = n_workers
 
     num_done = 0
     num_pushed_or_apied = 0

--- a/admin_migrations/migrators/r_automerge.py
+++ b/admin_migrations/migrators/r_automerge.py
@@ -153,15 +153,18 @@ class RAutomerge(Migrator):
     continual = True
 
     def migrate(self, feedstock, branch):
-        print("    r team:", _has_r_team(), flush=True)
-        print("    cran url:", _has_cran_url(), flush=True)
+        has_r_team = _has_r_team() or _has_r_team_rattler_build()
+        has_cran_url = _has_cran_url() or _has_cran_url_rattler_build()
 
         if (
             feedstock.startswith("r-")
             and feedstock != "r-base"
-            and (_has_r_team() or _has_r_team_rattler_build())
-            and (_has_cran_url() or _has_cran_url_rattler_build())
+            and has_r_team
+            and has_cran_url
         ):
+            print("    r team:", has_r_team, flush=True)
+            print("    cran url:", has_cran_url, flush=True)
+
             with Path("conda-forge.yml").open("r") as fp:
                 meta_yaml = fp.read()
 

--- a/admin_migrations/migrators/r_automerge.py
+++ b/admin_migrations/migrators/r_automerge.py
@@ -153,6 +153,10 @@ class RAutomerge(Migrator):
     continual = True
 
     def migrate(self, feedstock, branch):
+        if not (feedstock.startswith("r-") and feedstock != "r-base"):
+            # no migration, no commit needs to be made, no api calls
+            return False, False, False
+
         has_r_team = _has_r_team() or _has_r_team_rattler_build()
         has_cran_url = _has_cran_url() or _has_cran_url_rattler_build()
 

--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -20,7 +20,7 @@ class DummyMeta:
 
 class TeamsCleanup(Migrator):
     main_branch_only = True
-    max_processes = 2
+    max_processes = 1
     continual = True
 
     def _should_migrate(self):
@@ -28,8 +28,11 @@ class TeamsCleanup(Migrator):
             # we do 50 an hour
             self._time_between = 60.0 * 60.0 / MAX_PER_HOUR
 
+            # prevent a circular import by doing this here
+            from admin_migrations.__main__ import N_WORKERS
+
             # if we have more than one process, that time gets longer
-            self._time_between = self._time_between * self.max_processes
+            self._time_between = self._time_between * N_WORKERS
 
         now = time.time()
 

--- a/admin_migrations/migrators/username2id_mapping.py
+++ b/admin_migrations/migrators/username2id_mapping.py
@@ -100,7 +100,7 @@ def _add_remove_user(lines, user, action):
 
 class Username2IDMapping(Migrator):
     main_branch_only = True
-    max_processes = 2
+    max_processes = 1
 
     def migrate(self, feedstock, branch):
         if os.path.exists(UNAME2ID_FILE):


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.
