### PR TITLE
fix: do not wait for team update to complete

### DIFF
--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -60,6 +60,9 @@ class TeamsCleanup(Migrator):
             return
 
         if self._should_migrate() or "DEBUG_ADMIN_MIGRATIONS" in os.environ:
+            # we fire off this request and then do not bother
+            # to check the return value. the webservices will
+            # handle it eventually.
             # see https://stackoverflow.com/a/78879266
             try:
                 rsp = requests.post(

--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -60,6 +60,7 @@ class TeamsCleanup(Migrator):
             return
 
         if self._should_migrate() or "DEBUG_ADMIN_MIGRATIONS" in os.environ:
+            # see https://stackoverflow.com/a/78879266
             try:
                 rsp = requests.post(
                     "https://conda-forge.herokuapp.com/conda-forge-teams/update",

--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -60,12 +60,19 @@ class TeamsCleanup(Migrator):
             return
 
         if self._should_migrate() or "DEBUG_ADMIN_MIGRATIONS" in os.environ:
-            rsp = requests.post(
-                "https://conda-forge.herokuapp.com/conda-forge-teams/update",
-                headers={"CF_WEBSERVICES_TOKEN": os.environ["CF_WEBSERVICES_TOKEN"]},
-                json={"feedstock": repo_name},
-            )
-            rsp.raise_for_status()
+            try:
+                rsp = requests.post(
+                    "https://conda-forge.herokuapp.com/conda-forge-teams/update",
+                    headers={
+                        "CF_WEBSERVICES_TOKEN": os.environ["CF_WEBSERVICES_TOKEN"]
+                    },
+                    json={"feedstock": repo_name},
+                    timeout=(None, 0.00001),
+                )
+                rsp.raise_for_status()
+            except requests.exceptions.ReadTimeout:
+                pass
+
             print("    updated team", flush=True)
 
             # migration done, make a commit, lots of API calls


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.

There is no reason to wait on this call to complete.