### PR TITLE
fix: put this back

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.9
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [ --fix ]
     - id: ruff-format
 ci:

--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -1,12 +1,25 @@
 import os
-import time
+import random
 
 import requests
 from ruamel.yaml import YAML
 
+from admin_migrations.defaults import MAX_MIGRATE
+
 from .base import Migrator
 
-MAX_PER_HOUR = 50
+RNG = random.SystemRandom()
+
+
+def _get_random_frac():
+    # We do 100 per run of the code.
+    # this should be roughly 50 per hour.
+    if MAX_MIGRATE > 0:
+        frac = 100 / MAX_MIGRATE
+    else:
+        frac = 1
+
+    return frac
 
 
 class DummyMeta:
@@ -24,27 +37,10 @@ class TeamsCleanup(Migrator):
     continual = True
 
     def _should_migrate(self):
-        if not hasattr(self, "_time_between"):
-            # we do 50 an hour
-            self._time_between = 60.0 * 60.0 / MAX_PER_HOUR
-
-            # prevent a circular import by doing this here
-            from admin_migrations.__main__ import N_WORKERS
-
-            # if we have more than one process, that time gets longer
-            self._time_between = self._time_between * N_WORKERS
-
-        now = time.time()
-
-        if not hasattr(self, "_time_of_last_migration"):
-            self._time_of_last_migration = now
+        if RNG.random() < _get_random_frac():
             return True
-
-        if now - self._time_of_last_migration > self._time_between:
-            self._time_of_last_migration = now
-            return True
-
-        return False
+        else:
+            return False
 
     def migrate(self, feedstock, branch):
         repo_name = "%s-feedstock" % feedstock


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.
