### PR TITLE
fix: do not use team slug to get the team

### DIFF
--- a/admin_migrations/migrators/username2id_mapping.py
+++ b/admin_migrations/migrators/username2id_mapping.py
@@ -117,7 +117,17 @@ class Username2IDMapping(Migrator):
         # and properly retained permissions for people who have changed their
         # username. We want to write the IDs of the people on the feedstock
         # as it should be if we had done the same.
-        fs_team = org.get_team_by_slug(feedstock)
+        current_maintainer_teams = list(
+            org.get_repo(f"{feedstock}-feedstock").get_teams()
+        )
+        fs_team = next(
+            (team for team in current_maintainer_teams if team.name == feedstock),
+            None,
+        )
+        if fs_team is None:
+            # migration done, make a commit, lots of API calls
+            return False, False, True
+
         maintainers = {e.login.lower() for e in fs_team.get_members()}
 
         uname2id_mapping = {}


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.

Fixing this bug here. Will need to fix this in smithy too.