### PR TITLE
prod: only print if needed

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -67,3 +67,10 @@ jobs:
           AZURE_TOKEN: ${{ secrets.AZURE_TOKEN }}
           STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
           CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
+
+      - name: trigger next job
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
+        if: github.ref == 'refs/heads/main' && ! cancelled() && ! failure()
+        with:
+          workflow: migrate
+          token: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -1,6 +1,7 @@
 import contextlib
 import datetime
 import functools
+import io
 import json
 import os
 import subprocess
@@ -201,11 +202,6 @@ def run_migrators(feedstock, migrators) -> tuple[bool, list[tuple[Migrator, str]
     if len(migrators) == 0:
         return False, [], 0
 
-    print("=" * 80, flush=True)
-    print("=" * 80, flush=True)
-    print("=" * 80, flush=True)
-    print("migrating %s" % feedstock, flush=True)
-
     _start = time.time()
 
     made_api_calls = False
@@ -221,8 +217,20 @@ def run_migrators(feedstock, migrators) -> tuple[bool, list[tuple[Migrator, str]
         )
     )
 
+    buff = io.StringIO()
+    print_buff = False
+
     exit_code = 0
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with (
+        tempfile.TemporaryDirectory() as tmpdir,
+        contextlib.redirect_stdout(buff),
+        contextlib.redirect_stderr(buff),
+    ):
+        print("=" * 80, flush=True)
+        print("=" * 80, flush=True)
+        print("=" * 80, flush=True)
+        print("migrating %s" % feedstock, flush=True)
+
         with pushd(tmpdir):
             try:
                 # use a full depth clone since some migrators rely on
@@ -291,6 +299,8 @@ def run_migrators(feedstock, migrators) -> tuple[bool, list[tuple[Migrator, str]
                                 made_api_calls = made_api_calls or _made_api_calls
 
                                 if commit_me:
+                                    print_buff = True
+
                                     _run_git_command(
                                         [
                                             "commit",
@@ -319,6 +329,8 @@ def run_migrators(feedstock, migrators) -> tuple[bool, list[tuple[Migrator, str]
                                         )
 
                             except Exception as e:
+                                print_buff = True
+
                                 worked = False
                                 print("    ERROR:", repr(e), flush=True)
                                 print(
@@ -334,13 +346,18 @@ def run_migrators(feedstock, migrators) -> tuple[bool, list[tuple[Migrator, str]
                                 )
 
                             if worked:
+                                print_buff = True
                                 migrators_to_record.append((m, branch))
                             elif not m.continual:
+                                print_buff = True
                                 exit_code = 1
 
                             print(" ", flush=True)
 
-    print("\nmigration took %s seconds\n\n" % (time.time() - _start), flush=True)
+        print("\nmigration took %s seconds\n\n" % (time.time() - _start), flush=True)
+
+    if print_buff:
+        print(buff.getvalue(), flush=True)
 
     return made_api_calls, migrators_to_record, exit_code
 


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.
