### PR TITLE
prod: print even less

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -352,9 +352,7 @@ def run_migrators(feedstock, migrators) -> tuple[bool, list[tuple[Migrator, str]
                                 print_buff = True
                                 exit_code = 1
 
-                            print(" ", flush=True)
-
-        print("\nmigration took %s seconds\n\n" % (time.time() - _start), flush=True)
+        print("migration took %s seconds\n" % (time.time() - _start), flush=True)
 
     if print_buff:
         print(buff.getvalue(), flush=True)

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -261,7 +261,7 @@ def run_migrators(feedstock, migrators) -> tuple[bool, list[tuple[Migrator, str]
                     branches = _get_branches(default_branch)
 
                     for m in migrators:
-                        print("\nmigrator %s" % m.__class__.__name__, flush=True)
+                        print("migrator %s" % m.__class__.__name__, flush=True)
 
                         for branch in branches:
                             if branch != default_branch and m.main_branch_only:


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [x] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [x] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [x] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.
