### PR TITLE
fix: remove maintainers who do not exist

### DIFF
--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -444,7 +444,8 @@ def main() -> int:
 
     if DEBUG:
         # set DEBUG_ADMIN_MIGRATIONS in your env to enable this
-        all_feedstocks = ["cf-autotick-bot-test-package"]
+        # all_feedstocks = ["cf-autotick-bot-test-package"]
+        all_feedstocks = ["placekey"]
         feedstocks["feedstocks"] = all_feedstocks
         feedstocks["current_feedstock"] = "a"
         assert feedstocks["feedstocks"][0] > feedstocks["current_feedstock"]

--- a/admin_migrations/__main__.py
+++ b/admin_migrations/__main__.py
@@ -444,8 +444,7 @@ def main() -> int:
 
     if DEBUG:
         # set DEBUG_ADMIN_MIGRATIONS in your env to enable this
-        # all_feedstocks = ["cf-autotick-bot-test-package"]
-        all_feedstocks = ["placekey"]
+        all_feedstocks = ["cf-autotick-bot-test-package"]
         feedstocks["feedstocks"] = all_feedstocks
         feedstocks["current_feedstock"] = "a"
         assert feedstocks["feedstocks"][0] > feedstocks["current_feedstock"]

--- a/admin_migrations/migrators/username2id_mapping.py
+++ b/admin_migrations/migrators/username2id_mapping.py
@@ -148,10 +148,8 @@ class Username2IDMapping(Migrator):
             for uname in maintainers:
                 try:
                     uid = gh.get_user(uname).id
-                except Exception as e:
+                except github.GithubException.UnknownObjectException:
                     print(f"    null user id for {uname}", flush=True)
-                    print(f"    {repr(e)}", flush=True)
-                    assert False
                     uid = None
                     maint_to_remove.add(uname)
 
@@ -186,7 +184,7 @@ class Username2IDMapping(Migrator):
             for maint in recipe_maintainers:
                 try:
                     gh.get_user(maint)
-                except Exception:
+                except github.GithubException.UnknownObjectException:
                     if maint not in uname2id_mapping:
                         maint_to_remove.add(maint)
 

--- a/admin_migrations/migrators/username2id_mapping.py
+++ b/admin_migrations/migrators/username2id_mapping.py
@@ -148,11 +148,15 @@ class Username2IDMapping(Migrator):
             for uname in maintainers:
                 try:
                     uid = gh.get_user(uname).id
-                except Exception:
+                except Exception as e:
+                    print(f"    null user id for {uname}", flush=True)
+                    print(f"    {repr(e)}", flush=True)
+                    assert False
                     uid = None
-                print("    {uname}: {uid}", flush=True)
+                    maint_to_remove.add(uname)
 
-                uname2id_mapping[uname] = uid
+                if uid is not None:
+                    uname2id_mapping[uname] = uid
 
             print("    got username to id mapping", flush=True)
 

--- a/admin_migrations/migrators/username2id_mapping.py
+++ b/admin_migrations/migrators/username2id_mapping.py
@@ -141,6 +141,8 @@ class Username2IDMapping(Migrator):
             print("    wrote username to id mapping file", flush=True)
         else:
             maintainers = {e.login.lower() for e in fs_team.get_members()}
+            maint_to_remove = set()
+            maint_to_add = set()
 
             uname2id_mapping = {}
             for uname in maintainers:
@@ -148,12 +150,9 @@ class Username2IDMapping(Migrator):
                     uid = gh.get_user(uname).id
                 except Exception:
                     uid = None
+                print("    {uname}: {uid}", flush=True)
 
                 uname2id_mapping[uname] = uid
-
-            if any(val is None for val in uname2id_mapping.values()):
-                # migration done, make a commit, lots of API calls
-                return False, False, True
 
             print("    got username to id mapping", flush=True)
 
@@ -180,7 +179,6 @@ class Username2IDMapping(Migrator):
             )
             recipe_maintainers = {m.lower() for m in recipe_maintainers}
             recipe_maintainers = {m for m in recipe_maintainers if "/" not in m}
-            maint_to_remove = set()
             for maint in recipe_maintainers:
                 try:
                     gh.get_user(maint)
@@ -188,7 +186,6 @@ class Username2IDMapping(Migrator):
                     if maint not in uname2id_mapping:
                         maint_to_remove.add(maint)
 
-            maint_to_add = set()
             for maint in uname2id_mapping:
                 if maint not in recipe_maintainers:
                     maint_to_add.add(maint)

--- a/admin_migrations/migrators/username2id_mapping.py
+++ b/admin_migrations/migrators/username2id_mapping.py
@@ -148,7 +148,7 @@ class Username2IDMapping(Migrator):
             for uname in maintainers:
                 try:
                     uid = gh.get_user(uname).id
-                except github.GithubException.UnknownObjectException:
+                except github.UnknownObjectException:
                     print(f"    null user id for {uname}", flush=True)
                     uid = None
                     maint_to_remove.add(uname)
@@ -184,7 +184,7 @@ class Username2IDMapping(Migrator):
             for maint in recipe_maintainers:
                 try:
                     gh.get_user(maint)
-                except github.GithubException.UnknownObjectException:
+                except github.UnknownObjectException:
                     if maint not in uname2id_mapping:
                         maint_to_remove.add(maint)
 


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.
