### PR TITLE
perf: reduce number of team API calls to webserver

### DIFF
--- a/admin_migrations/migrators/teams_cleanup.py
+++ b/admin_migrations/migrators/teams_cleanup.py
@@ -12,11 +12,11 @@ RNG = random.SystemRandom()
 
 
 def _get_random_frac():
-    # We do 20 per run of the code per process.
+    # We do 10 per run of the code per process.
     if MAX_MIGRATE > 0:
-        frac = 20 / MAX_MIGRATE
+        frac = 10 / MAX_MIGRATE
     else:
-        frac = 0.01
+        frac = 0.005
 
     return frac
 


### PR DESCRIPTION
## Guidelines and Ground Rules

- [x] Don't migrate more than several hundred feedstocks per hour.
- [x] Make sure to put `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` in any commits to
      avoid massive rebuilds.
- [x] Rate-limit commits to feedstocks to in order to reduce the load on our admin webservices.
- [ ] Test your migration first. The `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock` is available to help test migrations.
- [ ] GitHub actions has a `GITHUB_TOKEN` in the environment. Please do not exhaust this
       token's API requests.
- [ ] Do not rerender feedstocks!

Items 1-3 are taken care of by the migrations code assuming you don't make any significant changes.

This should hopefully help reduce the load.